### PR TITLE
Bridge: Fix pairing persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,15 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      - roon-knob-bridge-data:/home/node/app/data
+      - roon-knob-bridge-data:/home/node/app/data  # Persists Roon pairing token
 
 volumes:
   roon-knob-bridge-data:
 ```
 
 > **Image tags:** Use `latest` for stable releases, or `edge` for bleeding-edge builds from master.
+>
+> **Volume:** The `data` volume stores your Roon pairing token. Without it, you'd need to re-authorize in Roon after every container restart.
 
 ```bash
 docker compose up -d

--- a/roon-extension/README.md
+++ b/roon-extension/README.md
@@ -26,8 +26,9 @@ The process will auto-discover your Roon Core on the LAN. Keep the Core’s “E
 | `PORT` | HTTP listen port (default `8088`). |
 | `LOG_LEVEL` | `debug` for verbose HTTP logs, otherwise `info` (default `info`). |
 | `MDNS_NAME` | Friendly service name advertised over `_roonknob._tcp`. |
-| `ROON_SERVICE_PORT` | TCP port used for the Roon discovery socket (defaults to `9330`). |
+| `ROON_SERVICE_PORT` | TCP port used for the Roon discovery socket (defaults to `9330`). This is NOT the HTTP port. |
 | `MDNS_BASE` | Optional base URL to advertise via mDNS (default `http://<hostname>:PORT`). |
+| `CONFIG_DIR` | Directory for persistent config storage (default `./data`). Used for Roon pairing tokens. |
 
 By default the knob ignores discovered bridges whose hostname isn’t a numeric IP (to avoid unresolvable names). If your mDNS advert uses a DNS name, set `MDNS_BASE` to the numeric IP that the knob can reach instead.
 

--- a/roon-extension/bridge.js
+++ b/roon-extension/bridge.js
@@ -3,6 +3,17 @@ const RoonApiStatus = require('node-roon-api-status');
 const RoonApiTransport = require('node-roon-api-transport');
 const RoonApiImage = require('node-roon-api-image');
 const { version: VERSION } = require('./package.json');
+const fs = require('fs');
+const path = require('path');
+
+// Config file path - use data directory for persistence in Docker
+const CONFIG_DIR = process.env.CONFIG_DIR || path.join(__dirname, 'data');
+const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
+
+// Ensure config directory exists
+if (!fs.existsSync(CONFIG_DIR)) {
+  fs.mkdirSync(CONFIG_DIR, { recursive: true });
+}
 
 const RATE_LIMIT_INTERVAL_MS = 100;
 const MAX_RELATIVE_STEP_PER_CALL = 25;
@@ -87,6 +98,38 @@ function createRoonBridge(opts = {}) {
       }, CORE_LOSS_TIMEOUT_MS);
     },
   });
+
+  // Override config storage to use data directory for Docker persistence
+  roon.save_config = function(k, v) {
+    try {
+      let config = {};
+      try {
+        const content = fs.readFileSync(CONFIG_FILE, { encoding: 'utf8' });
+        config = JSON.parse(content) || {};
+      } catch (e) {
+        // File doesn't exist yet, start fresh
+      }
+      if (v === undefined || v === null) {
+        delete config[k];
+      } else {
+        config[k] = v;
+      }
+      fs.writeFileSync(CONFIG_FILE, JSON.stringify(config, null, '    '));
+      log.debug('Config saved', { key: k, path: CONFIG_FILE });
+    } catch (e) {
+      log.error('Failed to save config', { error: e.message, path: CONFIG_FILE });
+    }
+  };
+
+  roon.load_config = function(k) {
+    try {
+      const content = fs.readFileSync(CONFIG_FILE, { encoding: 'utf8' });
+      const config = JSON.parse(content) || {};
+      return config[k];
+    } catch (e) {
+      return undefined;
+    }
+  };
 
   roon.service_port = opts.service_port || 9330;
 

--- a/roon-extension/server.js
+++ b/roon-extension/server.js
@@ -22,7 +22,8 @@ function startServer() {
   const PORT = parseInt(process.env.PORT || '8088', 10);
   const MDNS_NAME = process.env.MDNS_NAME || 'Roon Knob Bridge';
   const LOG_LEVEL = process.env.LOG_LEVEL || 'info';
-  const SERVICE_PORT = parseInt(process.env.ROON_SERVICE_PORT || '9330', 10);
+  // Roon discovery service port (not the HTTP port)
+  const ROON_SERVICE_PORT = parseInt(process.env.ROON_SERVICE_PORT || '9330', 10);
   const MDNS_BASE = process.env.MDNS_BASE || `http://${require('os').hostname()}:${PORT}`;
   const GIT_SHA = getGitSha();
 
@@ -34,7 +35,7 @@ function startServer() {
   app.use(cors());
   app.use(morgan(LOG_LEVEL === 'debug' ? 'dev' : 'tiny'));
 
-  const bridge = createRoonBridge({ service_port: SERVICE_PORT, display_name: MDNS_NAME, log: createLogger('Bridge') });
+  const bridge = createRoonBridge({ service_port: ROON_SERVICE_PORT, display_name: MDNS_NAME, log: createLogger('Bridge') });
   bridge.start();
 
   app.use(createRoutes({ bridge, metrics, log: createLogger('HTTP') }));
@@ -55,7 +56,7 @@ function startServer() {
   });
 
   const server = app.listen(PORT, () => {
-    log.info(`Listening on ${PORT}`, { service_port: SERVICE_PORT, base: MDNS_BASE });
+    log.info(`Listening on ${PORT}`, { roon_service_port: ROON_SERVICE_PORT, base: MDNS_BASE });
     try {
       advertise(PORT, {
         name: MDNS_NAME,


### PR DESCRIPTION
## Summary

Fix Roon pairing key not persisting across container restart.

Fixes #7

## Changes

- Override `roon.save_config/load_config` to use `data/config.json` so pairing tokens persist when `data/` is mounted as Docker volume
- Update README with clearer documentation about volume mount importance
- Add inline comment in docker-compose example

## Root Cause

The default `node-roon-api` stores config in a hardcoded `config.json` in the module directory, which doesn't persist across container restarts even when `data/` is mounted.

## Test plan

- [ ] Pair with Roon Core, restart container, verify pairing persists
- [ ] Check that `data/config.json` contains the pairing token after pairing

🤖 Generated with [Claude Code](https://claude.com/claude-code)