### PR TITLE
Allow manual OTA check to bypass dev version skip

### DIFF
--- a/idf_app/main/main_idf.c
+++ b/idf_app/main/main_idf.c
@@ -421,7 +421,7 @@ static void ui_loop_task(void *arg) {
         if (s_ota_check_pending) {
             s_ota_check_pending = false;
             ESP_LOGI(TAG, "Checking for firmware updates...");
-            ota_check_for_update();
+            ota_check_for_update(false);  // Auto-check: skip for dev versions
         }
         if (s_config_server_start_pending) {
             s_config_server_start_pending = false;

--- a/idf_app/main/ota_update.c
+++ b/idf_app/main/ota_update.c
@@ -351,18 +351,20 @@ void ota_init(void) {
     ESP_LOGI(TAG, "OTA initialized, current version: %s", s_ota_info.current_version);
 }
 
-void ota_check_for_update(void) {
+void ota_check_for_update(bool force) {
     if (s_ota_task != NULL) {
         ESP_LOGW(TAG, "OTA task already running");
         return;
     }
 
-    // Skip OTA checks for development/beta versions
-    const char *current = ota_get_current_version();
-    if (strstr(current, "-dev") || strstr(current, "-beta") || strstr(current, "-alpha")) {
-        ESP_LOGI(TAG, "Skipping OTA check for development version: %s", current);
-        s_ota_info.status = OTA_STATUS_UP_TO_DATE;
-        return;
+    // Skip OTA checks for development/beta versions (unless forced by user)
+    if (!force) {
+        const char *current = ota_get_current_version();
+        if (strstr(current, "-dev") || strstr(current, "-beta") || strstr(current, "-alpha")) {
+            ESP_LOGI(TAG, "Skipping OTA check for development version: %s", current);
+            s_ota_info.status = OTA_STATUS_UP_TO_DATE;
+            return;
+        }
     }
 
     xTaskCreate(check_update_task, "ota_check", 8192, NULL, 1, &s_ota_task);  // Low priority to not block UI

--- a/idf_app/main/ota_update.h
+++ b/idf_app/main/ota_update.h
@@ -28,7 +28,8 @@ typedef struct {
 void ota_init(void);
 
 // Check for updates (non-blocking, runs in background)
-void ota_check_for_update(void);
+// force=true bypasses the dev/beta/alpha version skip
+void ota_check_for_update(bool force);
 
 // Start firmware update (non-blocking, runs in background)
 void ota_start_update(void);

--- a/idf_app/main/ui_network.c
+++ b/idf_app/main/ui_network.c
@@ -362,9 +362,9 @@ static void check_update_cb(lv_event_t *e) {
         set_status_text("Starting update...");
         ota_start_update();
     } else {
-        // Check for updates
+        // Check for updates (force=true to bypass dev version skip)
         set_status_text("Checking...");
-        ota_check_for_update();
+        ota_check_for_update(true);
     }
     update_version_label();
 }


### PR DESCRIPTION
## Summary
- Auto-check on boot: skips for `-dev`/`-beta`/`-alpha` versions (no interruptions during testing)
- Manual check from settings: always checks (allows upgrading from dev to release)

## Changes
- Add `force` parameter to `ota_check_for_update(bool force)`
- `main_idf.c` auto-check passes `false`
- `ui_network.c` user-triggered check passes `true`

## Test plan
- [x] Build from tag (no `-dev`) - auto-check works normally
- [x] Local build (`-dev`) - auto-check skips
- [x] Local build (`-dev`) - manual check from settings finds release

🤖 Generated with [Claude Code](https://claude.com/claude-code)