### PR TITLE
feat: Add bridge connection retry status with recovery UX

### DIFF
--- a/common/roon_client.h
+++ b/common/roon_client.h
@@ -10,3 +10,10 @@ void roon_client_handle_input(ui_input_event_t event);
 void roon_client_set_network_ready(bool ready);
 const char* roon_client_get_artwork_url(char *url_buf, size_t buf_len, int width, int height);
 bool roon_client_is_ready_for_art_mode(void);
+
+// Bridge connection status (mirrors WiFi retry pattern for consistent UX)
+void roon_client_set_device_ip(const char *ip);  // Call when WiFi gets IP
+int roon_client_get_bridge_retry_count(void);    // Current retry attempt (0 = connected)
+int roon_client_get_bridge_retry_max(void);      // Max retries before showing recovery info
+bool roon_client_get_bridge_url(char *buf, size_t len);  // Get configured bridge URL
+bool roon_client_is_bridge_connected(void);      // True if bridge is responding

--- a/idf_app/main/main_idf.c
+++ b/idf_app/main/main_idf.c
@@ -293,6 +293,7 @@ void rk_net_evt_cb(rk_net_evt_t evt, const char *ip_opt) {
         ESP_LOGI(TAG, "WiFi connected with IP: %s", ip_opt ? ip_opt : "unknown");
         stop_wifi_msg_alternation();
         ui_update("WiFi: Connected", "", false, 0, 0, 100, 0, 0);
+        roon_client_set_device_ip(ip_opt);  // Store IP for bridge recovery messages
         roon_client_set_network_ready(true);
         // Defer heavy operations to UI task (sys_evt has limited stack)
         s_mdns_init_pending = true;  // mDNS needs network up first


### PR DESCRIPTION
## Summary

- Display "Testing Bridge" / "Attempt X of 5..." on main screen during bridge connection attempts
- After 5 failures, show "Update Bridge at:" / "http://<device-ip>" for easy recovery
- Add bridge status (Connected/Connecting/Unreachable) to web config page with color coding
- Slow polling to 10 seconds after max failures (was 1 second) to reduce log spam
- Skip bridge retry tracking in Bluetooth mode (not using bridge)
- Clear zone name during errors, restore on successful reconnect

## Test scenarios verified

- [x] Set invalid bridge URL (e.g., `http://192.168.1.2;8088` with semicolon instead of colon)
- [x] Device shows "Testing Bridge" / "Attempt 1 of 5..." through "Attempt 5 of 5..."
- [x] After 5 failures, "Update Bridge at:" / "http://<actual-ip>" is displayed on device
- [x] Access web config at shown IP, verify red "Unreachable" status displayed
- [x] Fix URL (or let mDNS discover correct one), verify "Connected" status shows (green)
- [x] Zone name properly restored after successful reconnect
- [x] Polling slows down after max failures (10 sec vs 1 sec)
- [x] "Searching for Bridge" / "via mDNS..." shown when no bridge URL configured

## Notes

- mDNS auto-discovery can self-heal invalid URLs if the bridge is advertising
- To test the full retry flow, either stop the bridge or use a URL pointing to non-existent host

Fixes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)