### PR TITLE
fix: Restore knob rotation for zone picker scrolling

### DIFF
--- a/common/ui.c
+++ b/common/ui.c
@@ -1076,8 +1076,13 @@ void ui_dispatch_input(ui_input_event_t input) {
 }
 
 void ui_handle_volume_rotation(int ticks) {
-    // Dispatch velocity-sensitive volume rotation to roon_client
-    roon_client_handle_volume_rotation(ticks);
+    if (ui_is_zone_picker_visible()) {
+        // Scroll zone picker instead of changing volume
+        ui_zone_picker_scroll(ticks > 0 ? 1 : -1);
+    } else {
+        // Dispatch velocity-sensitive volume rotation to roon_client
+        roon_client_handle_volume_rotation(ticks);
+    }
 }
 
 void ui_set_progress(int seek_ms, int length_ms) {


### PR DESCRIPTION
## Summary

Route encoder ticks to zone picker scroll when picker is visible, instead of always sending to volume control.

## Related Issues

Fixes #34 (regression from velocity-sensitive volume in v1.3.9)

## Test plan

- [x] Open zone picker, rotate knob - scrolls through zones
- [x] Close zone picker, rotate knob - changes volume

🤖 Generated with [Claude Code](https://claude.com/claude-code)