### PR TITLE
fix: Host firmware binaries on gh-pages to avoid CORS issues

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -319,12 +319,24 @@ jobs:
   deploy-pages:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    # TODO: Remove PR condition after testing
-    if: github.ref == 'refs/heads/master' || github.event_name == 'pull_request' || startsWith(github.ref, 'refs/tags/v')
+    needs: [release]
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download ESP32-S3 firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: esp32s3-firmware
+          path: esp32s3-artifacts
+
+      - name: Download ESP32 BT firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: esp32bt-firmware
+          path: esp32bt-artifacts
 
       - name: Prepare gh-pages content
         run: |
@@ -332,6 +344,9 @@ jobs:
           cp roon-extension/public/index.html gh-pages-build/
           cp roon-extension/public/flash.html gh-pages-build/
           cp roon-extension/public/manifest-*.json gh-pages-build/
+          # Copy merged binaries for web flashing (same-origin, no CORS issues)
+          cp esp32s3-artifacts/roon_knob_merged.bin gh-pages-build/
+          cp esp32bt-artifacts/esp32_bt_merged.bin gh-pages-build/
           echo "roon-knob.muness.com" > gh-pages-build/CNAME
           ls -la gh-pages-build/
 

--- a/roon-extension/public/manifest-bt.json
+++ b/roon-extension/public/manifest-bt.json
@@ -5,7 +5,7 @@
   "builds": [{
     "chipFamily": "ESP32",
     "parts": [{
-      "path": "https://github.com/muness/roon-knob/releases/latest/download/esp32_bt_merged.bin",
+      "path": "esp32_bt_merged.bin",
       "offset": 0
     }]
   }]

--- a/roon-extension/public/manifest-s3.json
+++ b/roon-extension/public/manifest-s3.json
@@ -5,7 +5,7 @@
   "builds": [{
     "chipFamily": "ESP32-S3",
     "parts": [{
-      "path": "https://github.com/muness/roon-knob/releases/latest/download/roon_knob_merged.bin",
+      "path": "roon_knob_merged.bin",
       "offset": 0
     }]
   }]


### PR DESCRIPTION
## Summary

- deploy-pages now depends on release job and only runs on tags
- Download firmware artifacts and copy merged bins to gh-pages
- Change manifest paths from GitHub releases URLs to relative paths
- Same-origin serving eliminates browser CORS restrictions

## Problem

ESP Web Tools couldn't fetch binaries from GitHub releases due to CORS. The GitHub releases URL goes through two 302 redirects to Azure blob storage which lacks `Access-Control-Allow-Origin` headers.

## Solution

Host the merged binaries on gh-pages alongside the flash page. Relative paths (`roon_knob_merged.bin`) instead of cross-origin URLs.

## Test plan

- [ ] Tag a release and verify gh-pages deploys with binaries
- [ ] Test flash page at roon-knob.muness.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)