### PR TITLE
docs: Promote web flasher and Extension Manager as primary install paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,26 +15,23 @@ See what's playing, adjust volume, skip tracks, and switch zones—all from a ph
 
 ## Quick Start
 
-> **New to Docker or ESP32 devices?** See the [Getting Started from Scratch](docs/usage/GETTING_STARTED.md) guide for detailed step-by-step instructions.
+> **New to this?** See the [Getting Started from Scratch](docs/usage/GETTING_STARTED.md) guide for detailed step-by-step instructions.
 
 ### 1. Flash the Firmware (one-time)
 
-Download `roon_knob.bin` from the [latest release](https://github.com/muness/roon-knob/releases/latest) and flash it to your knob:
+Use the [Web Flasher](https://roon-knob.muness.com/flash.html) in Chrome or Edge—no tools to install. Just plug in the knob via USB-C and click "Flash ESP32-S3".
 
-```bash
-pip install esptool
-esptool.py --chip esp32s3 -p /dev/tty.usbmodem101 -b 460800 \
-  --before default-reset --after hard-reset \
-  write_flash 0x10000 roon_knob.bin
-```
+> **Prefer command line?** See [Firmware Flashing](docs/usage/FIRMWARE_FLASHING.md) for esptool instructions.
 
-(Adjust the port for your system—see release notes for details.)
-
-After this initial flash, future updates happen automatically over WiFi.
+After flashing, future updates happen automatically over WiFi.
 
 ### 2. Run the Roon Extension
 
-The extension connects Roon to your knob. On a Docker host (NAS, Raspberry Pi, etc.):
+The extension connects Roon to your knob.
+
+**Docker (recommended)**
+
+On any Docker host (NAS, Raspberry Pi, etc.):
 
 ```yaml
 # docker-compose.yml
@@ -44,19 +41,19 @@ services:
     restart: unless-stopped
     network_mode: host
     volumes:
-      - roon-knob-bridge-data:/home/node/app/data  # Persists Roon pairing token
+      - roon-knob-bridge-data:/home/node/app/data
 
 volumes:
   roon-knob-bridge-data:
 ```
 
-> **Image tags:** Use `latest` for stable releases, or `edge` for bleeding-edge builds from master.
->
-> **Volume:** The `data` volume stores your Roon pairing token. Without it, you'd need to re-authorize in Roon after every container restart.
-
 ```bash
 docker compose up -d
 ```
+
+**Already have the [Roon Extension Manager](https://github.com/TheAppgineer/roon-extension-manager)?**
+
+Find "Roon Knob" in the extension list and install it from there.
 
 ### 3. Authorize in Roon
 

--- a/docs/usage/FIRMWARE_FLASHING.md
+++ b/docs/usage/FIRMWARE_FLASHING.md
@@ -11,33 +11,25 @@ The easiest way to flash firmware. Works directly in your browser using the Web 
 ### Requirements
 - **Browser**: Chrome or Edge (version 89+). Safari and Firefox are NOT supported.
 - **USB cable**: Connect your ESP32 board to your computer
-- **Download mode**: Device must be in bootloader mode (see steps below)
 
 ### Flashing the Main Controller (ESP32-S3)
 
 1. Connect the ESP32-S3 board via USB-C
-2. Put it in download mode:
-   - Hold the **BOOT** button
-   - Press the **RST** button
-   - Release the **BOOT** button
-3. Go to the flash page: `http://<bridge-ip>:8088/flash.html`
+2. Turn on the device (power slider towards USB-C port)
+3. Go to the **[Web Flasher](https://roon-knob.muness.com/flash.html)**
 4. Click **"Flash ESP32-S3"**
 5. Select the serial port when prompted
 6. Wait ~30 seconds for flashing to complete
 
 ### Flashing the Bluetooth Controller (ESP32)
 
-Only needed if you have the dual-chip configuration.
+Only needed if you want [Bluetooth mode](DUAL_CHIP_ARCHITECTURE.md).
 
-1. Connect the ESP32 board via USB (typically through a UART adapter)
-2. Put it in download mode:
-   - Hold the **BOOT** button
-   - Press the **EN** button
-   - Release the **BOOT** button
-3. Go to the flash page: `http://<bridge-ip>:8088/flash.html`
-4. Click **"Flash ESP32-BT"**
-5. Select the serial port when prompted
-6. Wait ~20 seconds for flashing to complete
+1. Flip the USB-C cable 180° to connect to the ESP32 chip
+2. Go to the **[Web Flasher](https://roon-knob.muness.com/flash.html)**
+3. Click **"Flash ESP32-BT"**
+4. Select the serial port when prompted
+5. Wait ~20 seconds for flashing to complete
 
 ### Chip Auto-Detection
 
@@ -134,7 +126,7 @@ Note: ESP32-S3 bootloader is at offset `0x0`, while ESP32 bootloader is at `0x10
 ## After Flashing
 
 After flashing a fresh device:
-1. The device will create a WiFi access point named "RoonKnob-XXXX"
+1. The device will create a WiFi access point named **"roon-knob-setup"**
 2. Connect to this network with your phone or computer
 3. A captive portal will open for WiFi configuration
 4. Enter your WiFi credentials

--- a/docs/usage/GETTING_STARTED.md
+++ b/docs/usage/GETTING_STARTED.md
@@ -29,25 +29,59 @@ The Waveshare knob contains **two separate chips**:
 
 | Chip | Firmware | What it does |
 |------|----------|--------------|
-| **ESP32-S3** | `roon_knob.bin` | Main chip: display, WiFi, touch, Roon control |
-| **ESP32** | `esp32_bt.bin` | Bluetooth chip: BLE HID controls + AVRCP metadata |
+| **ESP32-S3** | Main chip | Display, WiFi, touch, Roon control |
+| **ESP32** | Bluetooth chip | BLE HID controls + AVRCP metadata (optional) |
 
-**You must flash at least the ESP32-S3** (the main firmware). The ESP32 firmware is only needed if you want to use Bluetooth mode (controlling your phone/DAP when away from Roon).
+**You only need to flash the ESP32-S3** for normal Roon use. The ESP32 (Bluetooth) is only needed if you want [Bluetooth mode](DUAL_CHIP_ARCHITECTURE.md) for controlling your phone/DAP when away from Roon.
 
 ### How USB Works on This Device
 
 The knob has a clever trick: **flipping the USB-C cable switches which chip you're programming**. The connector works in either orientation, but each orientation connects to a different chip.
 
 - One orientation → ESP32-S3 (main chip)
-- Flip the cable → ESP32 (Bluetooth chip)
-
-You'll figure out which is which by the port name that appears (explained below).
+- Flip the cable 180° → ESP32 (Bluetooth chip)
 
 ### What You Need
 
 - The Waveshare ESP32-S3 Knob
 - A USB-C cable (data-capable, not charge-only)
-- A computer (Windows, Mac, or Linux)
+- A computer with **Chrome or Edge** browser (for web flasher)
+
+### Method 1: Web Flasher (Recommended)
+
+The easiest way to flash—no software to install.
+
+1. **Turn on the knob** (power slider towards the USB-C port)
+2. **Connect via USB-C** to your computer
+3. **Open the [Web Flasher](https://roon-knob.muness.com/flash.html)** in Chrome or Edge
+4. **Click "Flash ESP32-S3"** and select the serial port when prompted
+5. **Wait ~30 seconds** for flashing to complete
+
+The knob will restart and show "WiFi: Setup Mode" on its screen. That's perfect!
+
+**Which serial port?** Look for:
+- macOS: `cu.usbmodem...`
+- Windows: `COM3` or similar
+- Linux: `ttyACM0`
+
+**Optional: Flash Bluetooth Chip**
+
+1. Flip the USB-C cable 180° to connect to the other chip
+2. Click "Flash ESP32-BT" and select the new port (`cu.usbserial...` on Mac, `ttyUSB0` on Linux)
+
+**Troubleshooting:**
+
+| Problem | Solution |
+|---------|----------|
+| No serial port appears | Try a different USB cable (some only charge). Try flipping the USB-C cable. |
+| "Browser not supported" | Use Chrome or Edge. Safari and Firefox don't support Web Serial. |
+| Wrong chip detected | Flip the USB-C cable 180° to switch between chips. |
+
+---
+
+### Method 2: Command Line (esptool)
+
+For advanced users who prefer command-line tools. This requires Python.
 
 ### Step 1: Install Python and esptool
 
@@ -221,7 +255,11 @@ Note: The chip type is `esp32` (not `esp32s3`) for this firmware.
 
 ## Part 2: Run the Bridge
 
-The bridge is a small program that connects Roon to your knob. It runs in Docker, which is like a lightweight container that packages everything the program needs.
+The bridge is a small program that connects Roon to your knob. It needs to run on an always-on device (NAS, Raspberry Pi, etc.) on your network.
+
+**Already have the [Roon Extension Manager](https://github.com/TheAppgineer/roon-extension-manager)?** Just find "Roon Knob" in the extension list and install it. Skip to [Part 3](#part-3-connect-everything).
+
+For everyone else, we'll use Docker.
 
 ### What is Docker?
 


### PR DESCRIPTION
## Summary

Updates installation documentation to reflect the new web flasher and Extension Manager availability:

- **README**: Web flasher (roon-knob.muness.com) as primary flashing method, Docker recommended with Extension Manager mentioned for existing users
- **GETTING_STARTED**: Web flasher as Method 1, esptool as Method 2 for advanced users
- **FIRMWARE_FLASHING**: Updated to hosted flasher URL, fixed inconsistent WiFi AP name

🤖 Generated with [Claude Code](https://claude.com/claude-code)