### PR TITLE
fix: Resolve .local hostnames and prevent mDNS overwrites

### DIFF
--- a/common/platform/platform_mdns.h
+++ b/common/platform/platform_mdns.h
@@ -5,3 +5,7 @@
 
 void platform_mdns_init(const char *hostname);
 bool platform_mdns_discover_base_url(char *out, size_t len);
+
+// Resolve a .local hostname to IP address via mDNS
+// hostname can be "foo" or "foo.local" - .local suffix is stripped automatically
+bool platform_mdns_resolve_local(const char *hostname, char *ip_out, size_t ip_len);


### PR DESCRIPTION
## Summary

Fixes bridge URL configuration issues with mDNS hostnames:

- **Store IPs from mDNS discovery**: Auto-discovered bridge URLs now store IP addresses instead of hostnames (ESP32 lwIP has issues resolving `.local` DNS queries)
- **Respect user-set URLs**: mDNS discovery no longer overwrites manually configured bridge URLs
- **Resolve .local on save**: When users enter `.local` hostnames in web config, they're resolved to IPs before saving
- **Clear triggers fresh discovery**: The Clear button properly resets to mDNS auto-discovery

## Changes

- `platform_mdns_idf.c`: Extract IP from mDNS results instead of hostname; add `platform_mdns_resolve_local()` function
- `roon_client.c`: Only run mDNS discovery when `bridge_base` is empty
- `config_server.c`: Resolve `.local` URLs to IPs when saving; increase httpd stack to 8KB for mDNS queries

## Test plan

- [x] mDNS auto-discovery stores IP address (not hostname)
- [x] Manually set bridge URL persists across reboots
- [x] Entering `http://rooExtend.local:8088` resolves to IP and saves
- [x] Clear button triggers fresh mDNS discovery
- [x] No stack overflow during config save

🤖 Generated with [Claude Code](https://claude.com/claude-code)