### PR TITLE
fix: Track progress arc updates during playback (#44)

### DIFF
--- a/common/ui.c
+++ b/common/ui.c
@@ -597,8 +597,10 @@ static void apply_state(const struct ui_state *state) {
         if (progress_pct > 100) progress_pct = 100;
         if (progress_pct < 0) progress_pct = 0;
         lv_arc_set_value(s_progress_arc, progress_pct);
+        lv_obj_invalidate(s_progress_arc);
     } else if (s_progress_arc) {
         lv_arc_set_value(s_progress_arc, 0);
+        lv_obj_invalidate(s_progress_arc);
     }
 
     // Update play/pause icon

--- a/roon-extension/bridge.js
+++ b/roon-extension/bridge.js
@@ -167,6 +167,15 @@ function createRoonBridge(opts = {}) {
         if (Array.isArray(data?.zones_changed)) {
           data.zones_changed.forEach(updateZone);
         }
+        // Handle continuous seek position updates from Roon
+        if (Array.isArray(data?.zones_seek_changed)) {
+          data.zones_seek_changed.forEach((e) => {
+            const cached = state.nowPlayingByZone.get(e.zone_id);
+            if (cached && e.seek_position != null) {
+              cached.seek_position = e.seek_position;
+            }
+          });
+        }
       } else if (msg === 'NetworkError') {
         log.warn('Zone subscription network error - entering grace period');
         // Mark when transport became unavailable, but keep serving cached data briefly


### PR DESCRIPTION
## Summary

- Bridge: Handle `zones_seek_changed` events from Roon API for continuous seek position updates (was only handling `zones_changed`)
- UI: Add `lv_obj_invalidate()` to ensure progress arc redraws

## Root cause

Roon sends `seek_position` updates via `zones_seek_changed`, not `zones_changed`. The bridge was ignoring these events entirely, causing the progress arc to only update on volume/track changes.

## Test plan

- [x] Verified `seek_position` updates continuously via curl
- [x] Tested on device - progress arc now updates during playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress arc UI refresh to ensure immediate and consistent display updates across all progress states.
  * Enhanced real-time seek position synchronization to accurately reflect current playback position updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->