### PR TITLE
fix: Hide settings panel when update notification appears

### DIFF
--- a/common/ui.c
+++ b/common/ui.c
@@ -1336,6 +1336,9 @@ void ui_set_update_available(const char *version) {
         s_update_version[sizeof(s_update_version) - 1] = '\0';
         ESP_LOGI(UI_TAG, "Update available: %s", s_update_version);
 
+        // Hide settings panel so update button is visible
+        ui_hide_settings();
+
         // Create update button if it doesn't exist
         if (!s_update_btn && s_ui_container) {
             s_update_btn = lv_btn_create(s_ui_container);


### PR DESCRIPTION
## Summary

- Dismisses settings panel when an update is detected so the green update button is visible

## Problem

When checking for updates from the settings menu, the "Update to vX.Y.Z" button appeared behind the settings panel due to LVGL z-order (objects render in creation order).

## Solution

Call `ui_hide_settings()` in `ui_set_update_available()` before showing the update button.

## Test plan

- [ ] Open settings → Check for Update
- [ ] Verify settings panel closes and update button is visible (not hidden behind)

🤖 Generated with [Claude Code](https://claude.com/claude-code)