### PR TITLE
fix: Use correct web flasher URL in release notes

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -29,7 +29,7 @@ Then: `docker compose pull && docker compose up -d`
 
 ### Web Flasher (Recommended)
 
-Use the [web flasher](https://github.com/muness/roon-knob/blob/master/roon-extension/public/flash.html) in Chrome/Edge - no tools to install.
+Use the [web flasher](https://roon-knob.muness.com/flash.html) in Chrome/Edge - no tools to install.
 
 ### Command Line (esptool.py)
 


### PR DESCRIPTION
## Summary

- Fix web flasher link in release template to use `roon-knob.muness.com/flash.html` instead of GitHub blob URL

## Test plan

- [x] Verified URL matches other references in README.md and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Web Flasher link destination to point to the roon-knob.muness.com domain.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->