### PR TITLE
fix: Swipe gestures adapt to 180° rotation, add double-tap for art mode

### DIFF
--- a/common/roon_client.c
+++ b/common/roon_client.c
@@ -465,14 +465,12 @@ static bool fetch_now_playing(struct now_playing_state *state) {
         state->image_key[0] = '\0';  // No artwork available
     }
 
-    // Parse config_sha for config change detection
+    // Parse config_sha for config change detection (silent - checked in poll loop)
     const char *config_sha_key = strstr(resp, "\"config_sha\"");
     if (config_sha_key) {
         extract_json_string(config_sha_key, "\"config_sha\"", state->config_sha, sizeof(state->config_sha));
-        LOGI("now_playing: config_sha='%s'", state->config_sha);
     } else {
         state->config_sha[0] = '\0';
-        LOGI("now_playing: no config_sha in response");
     }
 
     // Note: Don't parse zones from now_playing response - it doesn't have zone_name

--- a/docs/esp/SWIPE_GESTURES.md
+++ b/docs/esp/SWIPE_GESTURES.md
@@ -137,8 +137,23 @@ Why defer? The touch callback runs from LVGL's internal context. Calling display
 |---------|--------|-----------|
 | Swipe Up | Enter art mode | dy < -60px, time < 500ms |
 | Swipe Down | Exit art mode | dy > +60px, time < 500ms |
+| Double-tap | Enter art mode | 2 taps within 400ms, < 40px apart |
+| Any tap | Exit art mode | (when in art mode) |
 
 Art mode hides the control UI and shows fullscreen album artwork.
+
+### Double-tap Detection
+
+Double-tap provides an alternative to swipe for entering art mode:
+
+```c
+#define DOUBLE_TAP_MAX_MS 400      // Max time between taps
+#define DOUBLE_TAP_MAX_DISTANCE 40 // Max movement between taps
+```
+
+The detector tracks the previous tap location and time. If a second tap occurs within the threshold, it enters art mode. This supplements (not replaces) swipe gestures for users who find swiping difficult.
+
+Note: Exiting art mode only requires a single tap anywhere on the screen, so double-tap detection is skipped when already in art mode.
 
 ## Coordinate System
 
@@ -152,6 +167,20 @@ So:
 
 - **Swipe up** = finger moves toward top of screen = negative dy
 - **Swipe down** = finger moves toward bottom = positive dy
+
+### Rotation Handling
+
+When the display is rotated 180°, the raw touch coordinates are inverted relative to the user's perspective. The gesture detection compensates by inverting dx/dy when `s_current_rotation == 180`:
+
+```c
+// Transform swipe direction for 180° rotation
+if (s_current_rotation == 180) {
+    dy = -dy;
+    dx = -dx;
+}
+```
+
+This ensures that a user's physical "swipe up" gesture always triggers art mode entry, regardless of display orientation.
 
 ## Why Software Implementation?
 


### PR DESCRIPTION
## Summary

- **#43** - Swipe gestures now adapt to 180° rotation. User's physical "swipe up" enters art mode regardless of display orientation.
- **#66** - Double-tap gesture added as alternative to swipe for entering art mode.

## Changes

### Rotation-aware swipes (#43)
When display is rotated 180°, raw touch coordinates are inverted. The gesture detector now transforms dx/dy based on `s_current_rotation`:

```c
if (s_current_rotation == 180) {
    dy = -dy;
    dx = -dx;
}
```

### Double-tap to enter art mode (#66)
- 2 taps within 400ms
- Less than 40px apart
- Only enters art mode (single tap exits)
- Supplements swipe for users who find swiping difficult

## Test plan

- [x] Test swipe up/down at 0° rotation → enters/exits art mode
- [x] Test swipe up/down at 180° rotation → enters/exits art mode
- [x] Test double-tap → enters art mode
- [x] Test single tap in art mode → exits art mode

Closes #43
Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)