### PR TITLE
fix(ui): Show auto-generated hostname on Settings screen

### DIFF
--- a/idf_app/main/ui_network.c
+++ b/idf_app/main/ui_network.c
@@ -160,7 +160,7 @@ static void refresh_labels(void) {
         if (cfg.knob_name[0]) {
             lv_label_set_text_fmt(s_widgets.name_value, "%s", cfg.knob_name);
         } else {
-            lv_label_set_text(s_widgets.name_value, "<unset>");
+            lv_label_set_text_fmt(s_widgets.name_value, "%s", wifi_mgr_get_hostname());
         }
     }
 


### PR DESCRIPTION
## Summary

- Settings screen now shows auto-generated hostname (roon-knob-XXXX) instead of "<unset>" when no explicit name is configured

## Context

Issue #71 has two parts:
1. **ESP32 Settings screen** - Fixed here ✅
2. **Hub GUI** - Requires fix in unified-hifi-control repo (separate PR)

When the knob boots, it auto-generates a hostname like `roon-knob-a1b2c3`. This should be the default name shown everywhere, with user-configured names taking priority.

## Test plan

- [x] Flash firmware
- [x] Open Settings screen when no explicit name is set
- [x] Verify hostname (e.g., "roon-knob-XXXX") is displayed instead of "<unset>"
- [x] Set name and confirm it is shown instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed network settings to display the actual hostname instead of showing a placeholder text when the hostname is not configured.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->