### PR TITLE
fix: Expand zone selector tap area with vertical padding (GH-90)

### DIFF
--- a/common/ui.c
+++ b/common/ui.c
@@ -374,6 +374,7 @@ static void build_layout(void) {
     lv_label_set_long_mode(s_zone_label, LV_LABEL_LONG_DOT);  // Truncate with ... if too long
     lv_obj_align(s_zone_label, LV_ALIGN_TOP_MID, 0, 50);  // Move down to avoid arc edge
     lv_obj_add_flag(s_zone_label, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_set_style_pad_ver(s_zone_label, 12, 0);  // Expand tap area vertically (GH-90)
     lv_obj_add_event_cb(s_zone_label, zone_label_event_cb, LV_EVENT_CLICKED, NULL);
     lv_obj_add_event_cb(s_zone_label, zone_label_long_press_cb, LV_EVENT_LONG_PRESSED, NULL);
 


### PR DESCRIPTION
## Summary

Fixes #90 

The zone selector label had no padding, making the tap target very small (~20-25px tall). This made it difficult to reliably select zones on the touchscreen.

## Changes

- Added 12px vertical padding to `s_zone_label` to expand the tap area to ~49px tall
- This matches the usability of zone picker buttons which use 18px vertical padding
- Visual appearance is preserved - padding extends the hit area without changing text position

## Testing

- [x] Build firmware successfully
- [x] Flash to device and verify zone selector is easier to tap
- [ ] Verify no layout issues or visual regressions

## Technical Details

**Before:** Label with no padding - tap area limited to text height (~20-25px)
**After:** Label with 12px vertical padding - tap area expanded to ~49px

Location: `common/ui.c:377` - added `lv_obj_set_style_pad_ver(s_zone_label, 12, 0);`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved zone label tap target area with adjusted vertical padding for enhanced touch and click accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->