### PR TITLE
fix: Increase max zones limit from 16/32 to 64

### DIFF
--- a/common/bridge_client.c
+++ b/common/bridge_client.c
@@ -31,7 +31,7 @@ static void check_charging_state_change(void);
 
 #define MAX_LINE 128
 #define MAX_ZONE_NAME 64
-#define MAX_ZONES 32
+#define MAX_ZONES 64
 #define POLL_DELAY_AWAKE_CHARGING_MS 2000   // 2 seconds when charging and display on
 #define POLL_DELAY_AWAKE_BATTERY_MS 5000   // 5 seconds on battery to save power
 #define POLL_DELAY_SLEEPING_MS 30000       // 30 seconds when display is sleeping

--- a/common/ui.c
+++ b/common/ui.c
@@ -86,7 +86,7 @@ static lv_timer_t *s_status_timer;     // Timer to clear status messages
 static lv_obj_t *s_zone_picker_overlay;    // Dark background overlay
 static lv_obj_t *s_zone_list;              // List widget for zone selection
 static bool s_zone_picker_visible = false;
-#define MAX_ZONE_PICKER_ZONES 16
+#define MAX_ZONE_PICKER_ZONES 64
 #define MAX_ZONE_ID_LEN 48
 static char s_zone_picker_ids[MAX_ZONE_PICKER_ZONES][MAX_ZONE_ID_LEN];  // Store zone IDs
 static int s_zone_picker_count = 0;


### PR DESCRIPTION
## Summary
- Increases `MAX_ZONES` in `bridge_client.c` from 32 to 64
- Increases `MAX_ZONE_PICKER_ZONES` in `ui.c` from 16 to 64

The UI zone picker was limited to 16 zones while the bridge client could store 32. Users with many zones (e.g., 17+) couldn't see all available zones in the picker.

Fixes #110

## Test plan
- [ ] Build firmware and flash
- [ ] Verify zones appear in picker (user has 17 zones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased maximum supported zones from 32 to 64
  * Expanded zone picker to accommodate up to 64 entries

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->