### PR TITLE
docs: Replace Beads with GitHub Issues as task tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,21 +4,18 @@
 
 | Tool | Binary/Skill | Purpose |
 |------|--------------|---------|
-| **Beads** | `bd` | Task tracking |
+| **GitHub Issues** | `gh` | Task tracking |
 | **Superego** | `sg` | Metacognitive review |
 | **Working Memory** | `wm` | Cross-session knowledge |
 | **Open Horizons** | MCP tools | Strategic endeavor tracking |
 | **Miranda** | `/miranda:*` | Workflow automation |
 
-First time after clone? Run `bd init --quiet`.
-
 ## When to Use Each
 
-**Beads (`bd`)** — Track what you're working on.
-- `bd ready` before starting
-- `bd sync` at end of session (after closing tasks)
-- Task types: `feature`, `bug`, `task`, `chore`, `epic` (priority 0-4, lower = higher)
-- Use `--deps parent-child:bd-XX` to nest subtasks under epics
+**GitHub Issues** — Track what you're working on.
+- `gh issue list` before starting
+- Create issues for new work, close them when done
+- Use task lists in parent issues to break down large features
 
 **Superego (`sg`)** — Second opinion at decision points.
 - Before committing to a plan or architecture
@@ -38,19 +35,18 @@ First time after clone? Run `bd init --quiet`.
 - `oh_create_guardrail_candidate` for constraints that should be enforced
 
 **Miranda** — Automate common workflows.
-- `/miranda:mouse` — Work a beads task end-to-end, create PR for review
-- `/miranda:drummer` — Batch review and merge open PRs
-- `/miranda:notes` — Address PR review comments
+- `/miranda:oh-task` — Work a GitHub issue end-to-end, create PR for review
+- `/miranda:oh-merge` — Batch review and merge open PRs for GitHub issues
+- `/miranda:oh-notes` — Address PR review comments
 
 ## Workflow
 
-1. `bd ready` — see what's available
-2. Claim a task, do the work
+1. `gh issue list` — see what's available
+2. Claim an issue, do the work
 3. `sg review` before committing if the change is significant
-4. `bd sync` at end of session
+4. Close the issue when done
 
 ## Principles
 
-- Beads is the source of truth for tasks (no Markdown TODOs)
+- GitHub Issues is the source of truth for tasks (no Markdown TODOs)
 - Superego catches strategic mistakes — invoke before committing to an approach
-- If `bd sync` complains about JSONL being newer, run `bd import` first

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,49 +25,42 @@ See [AGENTS.md](AGENTS.md) for complete instructions on working with this projec
 
 ## Key Points
 
-- This project uses **Beads (bd)** for all task and issue management
-- Initialize once per clone: `bd init --quiet`
-- Core workflow: check `bd ready`, claim tasks, sync when done
-- Always run `bd sync` at the end of a session
-- No external trackers, no Markdown TODOs
+- This project uses **GitHub Issues** for all task and issue management
+- No Markdown TODOs — create GitHub issues instead
 
 ## Roadmap-Driven Development
 
 The [README.md](README.md#roadmap) contains the project roadmap with release blockers and future improvements. When starting work:
 
 1. **Check the roadmap** in README.md to understand priorities
-2. **Check beads** for existing tasks: `bd ready`
-3. **Create beads tasks** for roadmap items if they don't exist yet
-4. **Break down large features** into fine-grained subtasks using beads parent-child relationships
+2. **Check GitHub Issues** for existing tasks: `gh issue list`
+3. **Create GitHub issues** for roadmap items if they don't exist yet
+4. **Break down large features** into subtasks (use task lists in the parent issue)
 5. **Update roadmap status** in README.md when features are completed
 
 ### Example Workflow
 
 ```bash
 # Check what's ready to work on
-bd ready
+gh issue list
 
-# If implementing a roadmap feature, create parent task first
-bd create "WiFi Provisioning (SoftAP)" -t epic -p 0 --json
+# If implementing a roadmap feature, create a tracking issue
+gh issue create --title "WiFi Provisioning (SoftAP)" --body "Tracking issue for WiFi provisioning"
 
-# Break into subtasks
-bd create "Add SoftAP mode to wifi_manager" -t task -p 1 --deps parent-child:bd-XX
-bd create "Create captive portal HTML" -t task -p 1 --deps parent-child:bd-XX
-bd create "Add provisioning timeout logic" -t task -p 1 --deps parent-child:bd-XX
+# Create subtask issues
+gh issue create --title "Add SoftAP mode to wifi_manager"
+gh issue create --title "Create captive portal HTML"
+gh issue create --title "Add provisioning timeout logic"
 
-# Claim and work on a subtask
-bd update bd-YY --status in_progress
-
-# Complete and sync
-bd close bd-YY --reason "implemented"
-bd sync
+# Work on a subtask, then close when done
+gh issue close <number> -c "Implemented in #<PR>"
 ```
 
 ### Keeping Roadmap in Sync
 
 - When a roadmap feature is **fully complete**, update its status in README.md from "Not started" to "Complete"
 - When work is **in progress**, update to "In progress"
-- Beads is the source of truth for task details; README roadmap is the high-level view
+- GitHub Issues is the source of truth for task details; README roadmap is the high-level view
 
 ## Git Workflow (MANDATORY)
 

--- a/docs/dev/DEVELOPMENT.md
+++ b/docs/dev/DEVELOPMENT.md
@@ -111,11 +111,10 @@ See [board overview](../esp/hw-reference/board.md) for pin mappings.
 
 ## Task Management
 
-We use [Beads](https://github.com/anthropics/beads) for task tracking:
+We use [GitHub Issues](https://github.com/muness/roon-knob/issues) for task tracking:
 
 ```bash
-bd ready              # List unblocked tasks
-bd update roon-knob-XX --status in_progress
-bd close roon-knob-XX -r "Implemented in v1.2.6"
-bd sync               # Push/pull with git
+gh issue list                          # List open issues
+gh issue create --title "Description"  # Create a new issue
+gh issue close <number> -c "Done"      # Close when complete
 ```

--- a/docs/meta/decisions/2025-12-20_DESIGN_KNOB_CONFIG.md
+++ b/docs/meta/decisions/2025-12-20_DESIGN_KNOB_CONFIG.md
@@ -248,4 +248,4 @@ Prerequisite for Phase 3. Options:
 - ADC voltage threshold (VBUS presence)
 - For USB-only setups: assume always charging
 
-This is covered by existing beads task `roon-knob-13q`.
+This is tracked as a GitHub issue.


### PR DESCRIPTION
## Summary
- Removes all references to Beads (`bd`) CLI across CLAUDE.md, AGENTS.md, DEVELOPMENT.md, and decision docs
- Replaces with GitHub Issues workflows using `gh` CLI
- Establishes GitHub Issues as the single source of truth for task tracking

## Test plan
- [ ] Grep confirms no remaining beads/bd references in .md files
- [ ] Workflow examples use correct `gh` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guides and agent configuration documentation to reflect GitHub Issues as the primary task-tracking system
  * Refreshed workflow examples and command references across multiple documentation files to align with GitHub Issues workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->