### PR TITLE
Add connection state visibility to UI

### DIFF
--- a/common/bridge_client.c
+++ b/common/bridge_client.c
@@ -593,6 +593,7 @@ static bool refresh_zone_label(bool prefer_zone_id) {
         if (s_device_state != DEVICE_STATE_OPERATIONAL) {
             LOGI("Device state: %s -> OPERATIONAL (zones loaded)", device_state_name(s_device_state));
             s_device_state = DEVICE_STATE_OPERATIONAL;
+            ui_set_network_status(NULL);  // Clear status banner when ready
         }
         success = should_sync && zone_label_copy[0] != '\0';
     }
@@ -929,6 +930,7 @@ void bridge_client_handle_input(ui_input_event_t event) {
                     if (s_device_state != DEVICE_STATE_OPERATIONAL) {
                         LOGI("Device state: %s -> OPERATIONAL (zone selected)", device_state_name(s_device_state));
                         s_device_state = DEVICE_STATE_OPERATIONAL;
+                        ui_set_network_status(NULL);  // Clear status banner when ready
                     }
                     s_trigger_poll = true;
                     s_force_artwork_refresh = true;  // Force artwork reload for new zone
@@ -1120,6 +1122,7 @@ void bridge_client_set_network_ready(bool ready) {
     if (ready) {
         LOGI("Device state: %s -> CONNECTED (network ready)", device_state_name(s_device_state));
         s_device_state = DEVICE_STATE_CONNECTED;  // Transition: WiFi connected, zones not yet loaded
+        ui_set_network_status("Loading zones...");
         s_trigger_poll = true;  // Trigger immediate poll when network becomes ready
     } else {
         // Transition to RECONNECTING if we were operational, otherwise back to BOOT
@@ -1128,6 +1131,7 @@ void bridge_client_set_network_ready(bool ready) {
             : DEVICE_STATE_BOOT;
         LOGI("Device state: %s -> %s (network lost)", device_state_name(s_device_state), device_state_name(new_state));
         s_device_state = new_state;
+        ui_set_network_status(new_state == DEVICE_STATE_RECONNECTING ? "Reconnecting..." : "Connecting...");
     }
     unlock_state();
 }


### PR DESCRIPTION
Closes #121

## Summary
Provides visual feedback during boot and reconnection by leveraging existing `ui_set_network_status()` to display persistent banners:
- "Connecting..." / "Reconnecting..." when network unavailable
- "Loading zones..." when network ready but zones not yet loaded
- Banner clears when device reaches OPERATIONAL state

## Implementation
Added 4 calls to `ui_set_network_status()` at state transitions in `bridge_client.c`:
- Lines 596, 933: Clear banner when OPERATIONAL
- Line 1119: Show "Loading zones..." when CONNECTED
- Line 1128: Show connection state when network lost

Reuses existing UI infrastructure, no new functions needed.

## Dependencies
Stacked on #123 (issue/120) - requires state machine implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Status messages now provide clearer feedback during zone loading and network connectivity changes, with specific indicators for reconnection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->