### PR TITLE
fix: long-press zone label opens settings in manifest UI

### DIFF
--- a/common/manifest_ui.c
+++ b/common/manifest_ui.c
@@ -293,7 +293,7 @@ static void zone_label_event_cb(lv_event_t *e) {
 static void zone_label_long_press_cb(lv_event_t *e) {
   (void)e;
   s_zone_long_pressed = true;
-  // Settings handled by bridge_client via UI_INPUT_MENU long press
+  ui_show_settings();
 }
 
 static void btn_prev_event_cb(lv_event_t *e) {


### PR DESCRIPTION
Closes #127

## Summary

Single-line fix: add `ui_show_settings()` call to `zone_label_long_press_cb` in `manifest_ui.c`.

In the manifest UI mode, long-pressing the zone label was a no-op (stub with only a comment). This restores the legacy `ui.c` behavior where long-press opens the settings panel.

**What is preserved:**
- `s_zone_long_pressed` flag still prevents click-after-long-press from opening zone picker
- Short-press still triggers `UI_INPUT_MENU` (zone picker) via separate callback
- No changes to `ui_show_settings()` implementation (platform-specific in `ui_network.c`)