### PR TITLE
Manifest UI: render list item sublabels and icons

### DIFF
--- a/common/manifest_ui.c
+++ b/common/manifest_ui.c
@@ -930,6 +930,9 @@ static void update_list_screen(const manifest_list_t *list) {
     lv_obj_set_layout(btn, LV_LAYOUT_FLEX);
     lv_obj_set_flex_flow(btn, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_style_pad_row(btn, 2, 0);
+    // Fix primary label width — flex column cross-axis doesn't auto-fill
+    lv_obj_t *primary_label = lv_obj_get_child(btn, 0);
+    if (primary_label) lv_obj_set_width(primary_label, lv_pct(100));
     lv_obj_set_style_bg_opa(btn, LV_OPA_TRANSP, 0);
     lv_obj_set_style_text_color(btn, COLOR_TEXT_PRIMARY, 0);
     lv_obj_set_style_text_font(btn, font_small(), 0);
@@ -939,6 +942,7 @@ static void update_list_screen(const manifest_list_t *list) {
       lv_label_set_text(sub, item->sublabel);
       lv_obj_set_style_text_font(sub, font_small(), 0);
       lv_obj_set_style_text_color(sub, COLOR_TEXT_DIM, 0);
+      lv_obj_set_width(sub, lv_pct(100));
       lv_label_set_long_mode(sub, LV_LABEL_LONG_DOT);
     }
 


### PR DESCRIPTION
Closes #128

## Summary

Renders sublabels from the manifest protocol below list item labels, using a flex column layout for vertical stacking.

### Changes

- **Flex column layout**: Each list item button now uses LV_FLEX_FLOW_COLUMN to stack label + sublabel vertically
- **Sublabel rendering**: When item->sublabel is non-empty, a secondary label is created with font_small() and COLOR_TEXT_DIM styling, with LV_LABEL_LONG_DOT truncation
- **Selection highlight**: Changed from grey (0x333333) to blue-tinted (0x2a4a6a), matching the legacy zone picker
- **No-sublabel items**: Render unchanged — single flex child looks identical to previous layout

### Files Changed

- common/manifest_ui.c — update_list_screen() only

### Not Included (per issue scope)

- Icon rendering (deferred — bridge sends icon: None, firmware lacks name-to-glyph mapping)
- No struct or parser changes (sublabel already parsed into manifest_list_item_t.sublabel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * List items now display sublabels with smaller, dimmed text when available.

* **Style**
  * Updated list item layout with columnar arrangement and tighter spacing.
  * Changed selected item background color for improved visual distinction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->