### PR TITLE
Manifest UI: persistent error state display during connection

### DIFF
--- a/common/bridge_client.c
+++ b/common/bridge_client.c
@@ -1290,12 +1290,16 @@ static void bridge_poll_thread(void *arg) {
       increment_bridge_fail_count();
       s_bridge_verified = false;
       char line1_msg[64];
+      char status_msg[96];
       snprintf(line1_msg, sizeof(line1_msg), "Attempt %d of %d...",
                s_bridge_fail_count, BRIDGE_FAIL_THRESHOLD);
       UI_SET_ZONE_NAME(""); // Clear zone name to avoid overlay
       UI_UPDATE(line1_msg, "Testing Bridge", false, 0.0f, 0.0f, 100.0f, 1.0f, 0,
                 0);
-      UI_SET_NETWORK_STATUS("Bridge: Offline - retrying...");
+      snprintf(status_msg, sizeof(status_msg),
+               "Testing Bridge\nAttempt %d of %d...", s_bridge_fail_count,
+               BRIDGE_FAIL_THRESHOLD);
+      UI_SET_NETWORK_STATUS(status_msg);
     } else if (!ok && !s_last_net_ok) {
       // Still trying to connect - check if we have a bridge URL
       lock_state();
@@ -1332,7 +1336,8 @@ static void bridge_poll_thread(void *arg) {
                    s_mdns_fail_count + 1, MDNS_FAIL_THRESHOLD);
           UI_UPDATE(line1_msg, "Searching for Bridge", false, 0.0f, 0.0f,
                     100.0f, 1.0f, 0, 0);
-          snprintf(status_msg, sizeof(status_msg), "mDNS: %d/%d",
+          snprintf(status_msg, sizeof(status_msg),
+                   "Searching for Bridge\nAttempt %d of %d...",
                    s_mdns_fail_count + 1, MDNS_FAIL_THRESHOLD);
           UI_SET_NETWORK_STATUS(status_msg);
         }
@@ -1350,8 +1355,7 @@ static void bridge_poll_thread(void *arg) {
             snprintf(line1_msg, sizeof(line1_msg), "http://%s", s_device_ip);
             snprintf(line2_msg, sizeof(line2_msg), "Update Bridge at:");
             snprintf(status_msg, sizeof(status_msg),
-                     "Bridge unreachable after %d attempts",
-                     BRIDGE_FAIL_THRESHOLD);
+                     "Bridge unreachable\nUpdate at http://%s", s_device_ip);
           } else {
             snprintf(line1_msg, sizeof(line1_msg), "Use zone menu > Settings");
             snprintf(line2_msg, sizeof(line2_msg), "Bridge Unreachable");
@@ -1370,7 +1374,8 @@ static void bridge_poll_thread(void *arg) {
           UI_SET_ZONE_NAME(""); // Clear zone name to avoid overlay
           UI_UPDATE(line1_msg, "Testing Bridge", false, 0.0f, 0.0f, 100.0f,
                     1.0f, 0, 0);
-          snprintf(status_msg, sizeof(status_msg), "Bridge: Retry %d/%d",
+          snprintf(status_msg, sizeof(status_msg),
+                   "Testing Bridge\nAttempt %d of %d...",
                    s_bridge_fail_count, BRIDGE_FAIL_THRESHOLD);
           UI_SET_NETWORK_STATUS(status_msg);
         }


### PR DESCRIPTION
Closes #129

## Summary

In manifest mode, `UI_UPDATE` is a noop, so error state details (attempt counts, header text like "Testing Bridge" or "Searching for Bridge") were lost. The `UI_SET_NETWORK_STATUS` calls existed and showed a persistent fullscreen banner, but with terse messages like `mDNS: 3/10` or `Bridge: Retry 2/10`.

This PR enriches all four error path network status messages to carry the full context:

| Error State | Before | After |
|---|---|---|
| Just lost connection | `Bridge: Offline - retrying...` | `Testing Bridge` + `Attempt 1 of 10...` |
| mDNS still searching | `mDNS: 3/10` | `Searching for Bridge` + `Attempt 3 of 10...` |
| Bridge unreachable (max retries, has IP) | `Bridge unreachable after 10 attempts` | `Bridge unreachable` + `Update at http://192.168.4.1` |
| Bridge configured, retrying | `Bridge: Retry 2/10` | `Testing Bridge` + `Attempt 2 of 10...` |

The network banner is already persistent and fullscreen with centered text (LV_LABEL_LONG_WRAP), so newlines in messages render as line breaks.

### Acceptance Criteria
- [x] Bridge search progress shows persistently with attempt count
- [x] Bridge offline state shows persistently with attempt count
- [x] mDNS failure recovery info (device IP) shows persistently
- [x] Messages clear when bridge connects (existing UI_SET_NETWORK_STATUS(NULL))
- [x] No blank screen periods - network banner persists until cleared


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced bridge connectivity status messages with clearer formatting and detailed attempt counters, providing better visibility into connection progress and troubleshooting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->