### PR TITLE
feat: progress arc colored from album art edge, black gutter border

### DIFF
--- a/common/bridge_client.c
+++ b/common/bridge_client.c
@@ -923,22 +923,12 @@ static void ui_manifest_cb(void *arg) {
 
   manifest_ui_update(m);
 
-  // Check artwork change
-  static char last_image_key[128] = "";
-  // Find media screen to get image_key
+  // Fetch artwork whenever screens are updated (SHA changed)
   for (int i = 0; i < m->screen_count; i++) {
     if (m->screens[i].type == SCREEN_TYPE_MEDIA) {
-      const char *key = m->screens[i].data.media.image_key;
       const char *url = m->screens[i].data.media.image_url;
-      bool force = s_force_artwork_refresh;
-      if (force) {
-        s_force_artwork_refresh = false;
-        last_image_key[0] = '\0';
-      }
-      if (key[0] && url[0] && (force || strcmp(key, last_image_key) != 0)) {
+      if (url[0]) {
         manifest_ui_set_artwork(url);
-        strncpy(last_image_key, key, sizeof(last_image_key) - 1);
-        last_image_key[sizeof(last_image_key) - 1] = '\0';
       }
       break;
     }

--- a/common/manifest_ui.h
+++ b/common/manifest_ui.h
@@ -67,7 +67,7 @@ void manifest_ui_set_status(bool online);
 void manifest_ui_set_message(const char *msg);
 
 /// Set album artwork by image key (triggers async fetch).
-void manifest_ui_set_artwork(const char *image_key);
+bool manifest_ui_set_artwork(const char *image_key);
 
 /// Show volume change overlay (optimistic UI during rotary input).
 void manifest_ui_show_volume_change(float vol, float vol_step);


### PR DESCRIPTION
## What

The progress arc indicator now takes its color from the album art edge color (same source as the background color). A black gutter arc sits behind it for contrast against any background.

## Changes

- **Progress gutter**: 8px wide black arc at diameter 334 (progress is 330/4px), provides 2px black border on each side
- **Progress indicator color**: Set from `bg_color` with `brighten_floor(80)` to ensure visibility on dark album art
- **Fallback**: Default blue (`COLOR_ARC_PROGRESS`) when no edge color available
- **Visibility sync**: Gutter shows/hides with progress arc

## Visual effect

The progress ring becomes part of the album's visual identity — colored to match the art, outlined in black for contrast regardless of background.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Non-interactive background element added behind the media progress indicator.
  * Progress color now derives from artwork edge colors with a minimum brightness applied.
  * Smarter seek handling to prefer local playhead progression and reduce unnecessary remote overrides.
  * Artwork loading now reports success/failure and handles display sizing more robustly.

* **Bug Fixes**
  * Progress background and arc visibility now stay synchronized.
  * Improved handling when no artwork color is available to ensure a readable progress color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->