### PR TITLE
fix: zone selector UX and WiFi retry timer race

### DIFF
--- a/idf_app/main/wifi_manager.c
+++ b/idf_app/main/wifi_manager.c
@@ -245,7 +245,14 @@ static esp_err_t apply_wifi_config(void) {
   return esp_wifi_set_config(WIFI_IF_STA, &cfg);
 }
 
-static void reset_backoff(void) { s_backoff_idx = 0; }
+static void reset_backoff(void) {
+  s_backoff_idx = 0;
+  // Cancel any pending retry timer — without this, a timer scheduled before
+  // GOT_IP can fire after connection succeeds and disconnect the working link.
+  if (s_retry_timer) {
+    esp_timer_stop(s_retry_timer);
+  }
+}
 
 static void schedule_retry_with_reason(uint8_t reason);
 static void schedule_retry(void);


### PR DESCRIPTION
## Summary
- **Zone picker UX**: Rotary scroll moves visual highlight + auto-scrolls, current zone pre-selected/highlighted on open, list padding for circular bezel, same-zone selection is a no-op, zone label hidden while picker is open
- **WiFi stability**: Cancel pending retry timer on GOT_IP — previously the timer could fire after connection succeeded, tearing down a working link and causing a reconnect loop
- **Zone marking**: bridge_client marks the current zone in manifest list data so the UI can highlight it

## Test plan
- [x] Open zone picker → current zone highlighted and scrolled into view
- [x] Rotate knob → highlight moves and auto-scrolls
- [x] Top/bottom items not clipped on circular display
- [x] Select already-active zone → closes silently (no "Loading zone...")
- [x] Open zone picker → let display dim → wake → zone label stays hidden
- [x] WiFi stabilizes after connecting (no reconnect loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Zone picker now tracks selection state, avoids no-op selection, preserves highlighting consistency, and scrolls chosen items into view.
  * List items record selection and scroll without animation when selected.
  * Increased list padding to prevent edge clipping near screen bezels.
  * Controls visibility no longer clears zone label when zone picker is visible; added safety checks to UI operations.
  * Wi‑Fi retry timer is canceled on reset to prevent unwanted reconnections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->