### PR TITLE
ci: support both idf_app and esp_dial firmware directories

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,9 @@ on:
     branches: [master, main]
     tags: ['v*']
   pull_request:
-    branches: [master, main]
+    branches: [master, main, v4]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -21,28 +23,38 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect firmware directory
+        id: fw
+        run: |
+          if [ -d "esp_dial" ]; then
+            echo "dir=esp_dial" >> $GITHUB_OUTPUT
+          else
+            echo "dir=idf_app" >> $GITHUB_OUTPUT
+          fi
+          echo "Firmware directory: $(cat $GITHUB_OUTPUT | grep dir= | cut -d= -f2)"
+
       - name: Get version from tag or CMakeLists
         id: version
         run: |
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           else
-            VERSION=$(grep 'set(PROJECT_VER' idf_app/CMakeLists.txt | sed 's/.*"\(.*\)".*/\1/')
+            VERSION=$(grep 'set(PROJECT_VER' ${{ steps.fw.outputs.dir }}/CMakeLists.txt | sed 's/.*"\(.*\)".*/\1/')
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Building firmware version: $VERSION"
 
       - name: Inject version into CMakeLists.txt
         run: |
-          sed -i 's/set(PROJECT_VER ".*")/set(PROJECT_VER "${{ steps.version.outputs.version }}")/' idf_app/CMakeLists.txt
-          grep PROJECT_VER idf_app/CMakeLists.txt
+          sed -i 's/set(PROJECT_VER ".*")/set(PROJECT_VER "${{ steps.version.outputs.version }}")/' ${{ steps.fw.outputs.dir }}/CMakeLists.txt
+          grep PROJECT_VER ${{ steps.fw.outputs.dir }}/CMakeLists.txt
 
       - name: Build with ESP-IDF
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: release-v5.5
           target: esp32s3
-          path: idf_app
+          path: ${{ steps.fw.outputs.dir }}
 
       - name: Create merged flash image for web flashing
         run: |
@@ -50,10 +62,10 @@ jobs:
           esptool --chip esp32s3 merge-bin \
             -o roon_knob_merged.bin \
             --flash-mode dio --flash-freq 80m --flash-size 16MB \
-            0x0 idf_app/build/bootloader/bootloader.bin \
-            0x8000 idf_app/build/partition_table/partition-table.bin \
-            0xd000 idf_app/build/ota_data_initial.bin \
-            0x10000 idf_app/build/roon_knob.bin
+            0x0 ${{ steps.fw.outputs.dir }}/build/bootloader/bootloader.bin \
+            0x8000 ${{ steps.fw.outputs.dir }}/build/partition_table/partition-table.bin \
+            0xd000 ${{ steps.fw.outputs.dir }}/build/ota_data_initial.bin \
+            0x10000 ${{ steps.fw.outputs.dir }}/build/roon_knob.bin
           ls -la *.bin
 
       - name: Upload ESP32-S3 artifact
@@ -61,7 +73,7 @@ jobs:
         with:
           name: esp32s3-firmware
           path: |
-            idf_app/build/roon_knob.bin
+            ${{ steps.fw.outputs.dir }}/build/roon_knob.bin
             roon_knob_merged.bin
           retention-days: 30
 
@@ -122,7 +134,9 @@ jobs:
       - name: Prepare release assets
         run: |
           mkdir -p release-assets
-          cp esp32s3-artifacts/idf_app/build/roon_knob.bin release-assets/
+          # Find the firmware binary (could be under idf_app/ or esp_dial/)
+          FW_BIN=$(find esp32s3-artifacts -name roon_knob.bin -type f | head -1)
+          cp "$FW_BIN" release-assets/
           cp esp32s3-artifacts/roon_knob_merged.bin release-assets/
           ls -la release-assets/
 


### PR DESCRIPTION
## Summary
- Auto-detect firmware directory (`esp_dial` or `idf_app`) so CI works for both master and v4/feature branches with the directory rename
- Add `v4` to pull_request branch targets
- Add `workflow_dispatch` trigger for manual runs
- Use `find` for release asset paths to handle either directory structure

This unblocks CI for PR #176 (command-pattern manifest) which renames `idf_app` → `esp_dial`.

## Test plan
- [ ] CI triggers on this PR itself (proves the workflow is valid)
- [ ] After merge, PR #176 CI will trigger on next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)