### PR TITLE
fix: URL-decode WiFi passwords before truncating to buffer size

### DIFF
--- a/idf_app/main/CMakeLists.txt
+++ b/idf_app/main/CMakeLists.txt
@@ -69,5 +69,6 @@ idf_component_register(
 set_property(TARGET ${COMPONENT_LIB} PROPERTY C_STANDARD 11)
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE TARGET_PC=0)
+# TODO(#183): Remove after ESP-IDF 6.0 migration (Picolibc has proper strlcpy)
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error=stringop-truncation)
 

--- a/idf_app/main/CMakeLists.txt
+++ b/idf_app/main/CMakeLists.txt
@@ -69,4 +69,5 @@ idf_component_register(
 set_property(TARGET ${COMPONENT_LIB} PROPERTY C_STANDARD 11)
 
 target_compile_definitions(${COMPONENT_LIB} PRIVATE TARGET_PC=0)
+target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error=stringop-truncation)
 

--- a/idf_app/main/captive_portal.c
+++ b/idf_app/main/captive_portal.c
@@ -110,13 +110,23 @@ static bool get_form_field(const char *data, const char *field, char *out, size_
     const char *end = strchr(start, '&');
     size_t len = end ? (size_t)(end - start) : strlen(start);
 
-    if (len >= out_len) {
-        len = out_len - 1;
+    // URL-encoded data can be up to 3x the decoded length (e.g. ! -> %21).
+    // Decode in a temporary buffer first, then truncate to fit the output.
+    char encoded[256];
+    if (len >= sizeof(encoded)) {
+        len = sizeof(encoded) - 1;
     }
 
-    memcpy(out, start, len);
-    out[len] = '\0';
-    url_decode(out);
+    memcpy(encoded, start, len);
+    encoded[len] = '\0';
+    url_decode(encoded);
+
+    size_t decoded_len = strlen(encoded);
+    if (decoded_len >= out_len) {
+        decoded_len = out_len - 1;
+    }
+    memcpy(out, encoded, decoded_len);
+    out[decoded_len] = '\0';
     return true;
 }
 

--- a/idf_app/main/config_server.c
+++ b/idf_app/main/config_server.c
@@ -109,13 +109,23 @@ static bool get_form_field(const char *data, const char *field, char *out, size_
     const char *end = strchr(start, '&');
     size_t len = end ? (size_t)(end - start) : strlen(start);
 
-    if (len >= out_len) {
-        len = out_len - 1;
+    // URL-encoded data can be up to 3x the decoded length (e.g. ! -> %21).
+    // Decode in a temporary buffer first, then truncate to fit the output.
+    char encoded[256];
+    if (len >= sizeof(encoded)) {
+        len = sizeof(encoded) - 1;
     }
 
-    memcpy(out, start, len);
-    out[len] = '\0';
-    url_decode(out);
+    memcpy(encoded, start, len);
+    encoded[len] = '\0';
+    url_decode(encoded);
+
+    size_t decoded_len = strlen(encoded);
+    if (decoded_len >= out_len) {
+        decoded_len = out_len - 1;
+    }
+    memcpy(out, encoded, decoded_len);
+    out[decoded_len] = '\0';
     return true;
 }
 


### PR DESCRIPTION
## Summary
- WiFi passwords with special characters silently corrupted during captive portal setup
- URL-encoded data truncated to 65 bytes *before* decoding — special chars expand 3x, get chopped, decode to garbage → "Wrong Password"
- Fix: decode into intermediate 256-byte buffer first, then truncate the decoded result
- Suppresses `-Werror=stringop-truncation` for newer GCC (will be removed with ESP-IDF 6.0 migration, #183)

## Test plan
- [x] Flash and connect with short simple password
- [x] Connect with 63-character password containing special characters (`!@#$%^&*`)
- [x] Verify bridge reachable after connecting

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer handling of URL-encoded form fields in the captive portal and configuration server to avoid buffer overruns when decoding and truncating input.
* **Chores**
  * Adjusted a component-level compiler option to relax treating certain string truncation warnings as errors during build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->