### PR TITLE
docs: correct and attribute the round-target identity (#211)

### DIFF
--- a/.github/workflows/docs-identity.yml
+++ b/.github/workflows/docs-identity.yml
@@ -1,0 +1,133 @@
+name: Docs Identity Guard
+
+# Issue #211. Independent of docker.yml on purpose: this is a host-only check with
+# no ESP-IDF container, no artifacts, and no dependency on any other workflow or on
+# unmerged release-config work (PR #204). It reads documentation and runs Python
+# from the standard library.
+#
+# Status: advisory until #205 adds required status checks on master. A red run is
+# visible on the pull request but does not block a merge until then.
+#
+# Advisory red decays: a check nobody has to pass is a check people learn to scroll
+# past, and this one is deliberately loud. So leaving it advisory indefinitely is a
+# real failure mode, not a neutral state -- but no date is set here, because a date
+# in a comment enforces nothing and expires without anyone noticing. Whether this
+# job becomes required or is retired is tracked in #213, which gates #205.
+#
+# Also runnable locally, and not from scripts/ci_sanity.sh -- that script needs a
+# toolchain. See docs/dev/DEVELOPMENT.md and AGENTS.md for the direct host-only
+# command.
+#
+# No `paths:` filter, deliberately. The earlier cut only ran when Markdown or the
+# checker changed, which makes the job *skipped* rather than green on every other
+# pull request -- and a required status check that can be skipped is a required
+# check that can be bypassed by touching no Markdown. Running unconditionally
+# costs one short host job and means the check always reports, so #205 can require
+# it without any further change here. The scan is repo-wide, so there is nothing to
+# narrow to anyway; the one bot-managed exemption (root CHANGELOG.md, written by
+# changelog.yml) lives in the checker's SKIP_FILES and is covered by the fixture
+# suite rather than duplicated as a path filter.
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-identity-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-identity:
+    name: Target identity contradiction guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Record interpreter identity
+        run: |
+          python3 --version
+          bash --version | head -1
+
+      # The fixture suite proves both directions -- that current docs are accepted
+      # and that each guarded contradiction is rejected -- it exercises the
+      # independent paraphrase corpus, and it also proves the checker's own
+      # --self-check is live. Run it before the repository check so a broken guard
+      # is reported as a broken guard, not as clean documentation.
+      - name: Fixture suite
+        run: bash scripts/test_check_docs_identity.sh
+
+      # --self-check is not optional here: without it, a rule whose regex stopped
+      # matching anything would report a clean repository forever. It also proves
+      # that rule-level `unless` suppressions are still recorded, so the guard
+      # cannot narrow itself invisibly.
+      #
+      # Exit contract, in precedence order: 3 MISSING, 4 SELFCHECK, 2 STRUCTURE,
+      # 1 VIOLATION, 0 OK (64 is a bad invocation). Structure outranks violation
+      # deliberately: a document whose HTML comment or code fence is opened and
+      # never closed hides its own tail, so it is exactly the state in which a
+      # contradiction cannot be seen, and it is reported as STRUCTURE naming the
+      # file and the opening line rather than absorbed. Outranked tokens are still
+      # printed, so nothing is hidden by precedence.
+      #
+      # Source anchors: the canonical record's repository-observed rows cite source
+      # files, and prose rules cannot see a citation rot. SOURCE_ANCHORS asserts
+      # that each cited file still carries its expected tokens; an absent file or a
+      # missing token is a named STRUCTURE finding. Each token is a whole line or
+      # block that states the relationship the row cites, matched
+      # whitespace-insensitively and word-boundary guarded, so a pair of fragments
+      # cannot both be present while the relationship between them is gone.
+      #
+      # Three limits, stated here because a green run invites all three assumptions:
+      #   * an anchor is a freshness check on the citation, not evidence the fact is
+      #     true -- a missing token means "re-read the source", not "the claim is
+      #     false";
+      #   * an anchor checks text, NEVER the line numbers a row cites, so pure line
+      #     movement leaves every `:NN` in the Markdown stale with the guard still
+      #     green. That is human-review work, tracked in #213;
+      #   * `anchors_fresh=N/N` is not coverage. The table covers a subset of the
+      #     repository-observed rows; negative and uniqueness rows cannot be anchored
+      #     at all, and neither can derived counts or anything about the silicon.
+      #
+      # Report contract: --report writes one JSON object whose `token` and
+      # `exit_code` agree with this step's status. Finding groups are `violations`,
+      # `marker_abuse`, `structure_failures`, `missing` and `selfcheck_failures`.
+      # `suppressions` is informational -- every hit a rule's `unless` clause
+      # excused, with file, line, rule id, matched text and the suppressor that
+      # excused it. Suppressions never change the exit code; they are reported so a
+      # widened suppressor is visible in review, and the fixture suite additionally
+      # pins the repository's suppression *set* as an exact
+      # rule|file|suppressor|count fingerprint -- so swapping one suppressor for
+      # another fails at an unchanged total, and an additional suppressed hit inside
+      # a triple the baseline already lists fails on the count -- making a change
+      # review friction rather than a silent narrowing. `quoting_note` carries the
+      # checker's statement that a four-space indented block is scanned as prose
+      # rather than exempted as code, so quoted source belongs in a fenced block; the
+      # renderer prints it beneath the violations it explains.
+      # `source_anchors` is the full inventory with each anchor's status,
+      # so a reader sees what was checked and not only what failed, and
+      # `source_anchor_scope` carries the checker's own statement of the three limits
+      # above. `rules` is the size of the rule table, not a count of covered
+      # alternation branches.
+      - name: Check repository documentation
+        run: |
+          python3 scripts/check_docs_identity.py \
+            --self-check \
+            --report "$RUNNER_TEMP/rk_docs_identity.json"
+
+      # The renderer is a tested script, not a heredoc: scripts/summarize_docs_identity.py
+      # is exercised by the fixture suite above, including the all-groups report
+      # shape and the informational suppressions group. It always exits 0, so it
+      # cannot mask the checker's exit code.
+      - name: Summarise
+        if: always()
+        run: |
+          python3 scripts/summarize_docs_identity.py \
+            --report "$RUNNER_TEMP/rk_docs_identity.json" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,3 +50,8 @@
 
 - GitHub Issues is the source of truth for tasks (no Markdown TODOs)
 - Superego catches strategic mistakes — invoke before committing to an approach
+- After editing Markdown or the hardware sources it cites, run
+  `python3 scripts/check_docs_identity.py --self-check` (host-only, no ESP-IDF).
+  It guards the canonical target-identity record `docs/esp/hw-reference/board.md`.
+  It is a phrase tripwire, not a factual check — a green run is not a substitute
+  for reviewing identity claims on their merits.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roon Knob
 
-Custom firmware and a companion service that turn a [Waveshare ESP32-S3 Knob](https://www.waveshare.com/esp32-s3-knob-touch-lcd-1.8.htm) into a dedicated hi-fi controller.
+Custom firmware and a companion service that turn a [Waveshare ESP32-S3 Knob](https://www.waveshare.com/esp32-s3-knob-touch-lcd-1.8.htm) into a dedicated hi-fi controller. See the [canonical hardware identity and provenance record](docs/esp/hw-reference/board.md) for the exact target.
 
 See what's playing, adjust volume, skip tracks, and switch zones—all from a physical knob on your desk.
 
@@ -77,8 +77,8 @@ The knob finds the extension automatically via mDNS.
 | Action | What it does |
 |--------|--------------|
 | **Turn the knob** | Volume up/down |
-| **Press the knob** | Open zone picker |
-| **Tap the screen** | Play/pause |
+| **Tap the zone name** | Open zone picker |
+| **Tap the centre button** | Play/pause |
 | **Swipe up** | Art mode (hide controls, show album art) |
 | **Swipe down** | Exit art mode |
 | **Long-press zone name** | Settings |

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,8 +40,8 @@ Developer reference for building and extending the firmware.
 
 ESP32 hardware-specific documentation.
 
-- [DISPLAY.md](esp/DISPLAY.md) - SH8601 AMOLED setup, LVGL integration
-- [TOUCH_INPUT.md](esp/TOUCH_INPUT.md) - CST816 touch controller
+- [DISPLAY.md](esp/DISPLAY.md) - QSPI panel setup, LVGL integration
+- [TOUCH_INPUT.md](esp/TOUCH_INPUT.md) - Touch controller integration
 - [SWIPE_GESTURES.md](esp/SWIPE_GESTURES.md) - Gesture detection
 - [ROTARY_ENCODER.md](esp/ROTARY_ENCODER.md) - Quadrature encoder handling
 - [BATTERY_MONITORING.md](esp/BATTERY_MONITORING.md) - ADC-based battery level
@@ -51,10 +51,10 @@ ESP32 hardware-specific documentation.
 
 Pin mappings, datasheets, component details.
 
-- [board.md](esp/hw-reference/board.md) - Board overview and specs
+- **[board.md](esp/hw-reference/board.md) - Canonical target identity record (provenance-classed). Start here for any product, panel, controller, memory, or encoder fact.**
 - [HARDWARE_PINS.md](esp/hw-reference/HARDWARE_PINS.md) - GPIO assignments
-- [COLORTEST_HELLOWORLD.md](esp/hw-reference/COLORTEST_HELLOWORLD.md) - Display color format
-- [cst816d.md](esp/hw-reference/cst816d.md) - Touch controller details
+- [COLORTEST_HELLOWORLD.md](esp/hw-reference/COLORTEST_HELLOWORLD.md) - RGB565 byte order and colour format
+- [cst816d.md](esp/hw-reference/cst816d.md) - Touch controller integration notes
 - [encoder.md](esp/hw-reference/encoder.md) - Rotary encoder interface
 - [battery.md](esp/hw-reference/battery.md) - Battery monitoring circuit
 - [drv2605.md](esp/hw-reference/drv2605.md) - Haptic motor driver
@@ -76,6 +76,7 @@ Date-prefixed architectural decision records.
 - [2025-12-20_DESIGN_KNOB_CONFIG.md](meta/decisions/2025-12-20_DESIGN_KNOB_CONFIG.md) - Per-knob config from bridge
 - [2025-12-20_DECISION_ROTATION.md](meta/decisions/2025-12-20_DECISION_ROTATION.md) - Display rotation (0/180 only)
 - [2025-12-20_DECISION_JSON_PARSING.md](meta/decisions/2025-12-20_DECISION_JSON_PARSING.md) - cJSON for API parsing
+- [2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md](meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md) - One provenance-classed identity record, enforced by a host check
 
 ### Analysis
 

--- a/docs/dev/BOOT_SEQUENCE.md
+++ b/docs/dev/BOOT_SEQUENCE.md
@@ -22,7 +22,7 @@ app_main()
 ┌────────────────────────────────────────────────────────────────┐
 │ 2. Display Hardware Init                                       │
 │    - SPI bus initialization                                    │
-│    - SH8601 LCD panel driver                                   │
+│    - QSPI LCD panel driver (esp_lcd_sh8601 component)          │
 │    - I2C bus (touch controller, haptic motor)                  │
 │    - CST816 touch controller                                   │
 │    - PWM backlight                                             │

--- a/docs/dev/DEVELOPMENT.md
+++ b/docs/dev/DEVELOPMENT.md
@@ -98,16 +98,53 @@ Bridge code is at [unified-hifi-control](https://github.com/cloud-atlas-ai/unifi
 
 ## Hardware
 
-The [Waveshare ESP32-S3-Knob-Touch-LCD-1.8](https://www.waveshare.com/wiki/ESP32-S3-Knob-Touch-LCD-1.8) includes:
+The target is the [Waveshare ESP32-S3-Knob-Touch-LCD-1.8](https://www.waveshare.com/wiki/ESP32-S3-Knob-Touch-LCD-1.8).
 
-- ESP32-S3 with 16MB Flash + 8MB PSRAM
-- 1.8" 360×360 IPS LCD (SH8601 via QSPI)
-- CST816 capacitive touch (I2C)
-- Rotary encoder with push button
-- Battery management (charging + voltage monitoring)
-- Vibration motor
+**Do not restate hardware facts here.** The canonical, provenance-classed identity record —
+exact part numbers, panel technology and driver IC, colour depth, memory sizes, backlight,
+touch, encoders, and the list of facts still awaiting physical verification — is
+[docs/esp/hw-reference/board.md](../esp/hw-reference/board.md). Pin mappings are in
+[HARDWARE_PINS.md](../esp/hw-reference/HARDWARE_PINS.md).
 
-See [board overview](../esp/hw-reference/board.md) for pin mappings.
+One behavioural note that matters when you build a UI: this firmware reads **no** physical
+button. Rotation comes from the encoder; every button-like action comes from the touchscreen.
+
+### Checking documentation identity claims
+
+After editing Markdown, or after editing the hardware sources the canonical record cites, run:
+
+```bash
+python3 scripts/check_docs_identity.py --self-check
+```
+
+Host-only: Python standard library, no ESP-IDF, no network, no writes. It is deliberately
+not wired into `scripts/ci_sanity.sh` — that script's next step is `idf.py build`, so it cannot run
+on a host without a toolchain, which is exactly the host this command is for. Run it directly.
+`.github/workflows/docs-identity.yml` runs the same command in CI, together with
+`scripts/test_check_docs_identity.sh`.
+
+What it does and does not do:
+
+- It is a **phrase tripwire** for the specific identity contradictions that
+  [#211](https://github.com/muness/roon-knob/issues/211) corrected. A novel wording will pass, so a
+  green run is not a substitute for reviewing identity claims on their merits.
+- It checks that the source files the canonical record's repository-observed rows cite still
+  contain the text those rows were read from. That is a freshness check on the citation, not
+  evidence the fact is true — and it does **not** check the line numbers those rows cite, so a
+  citation can go stale from line movement alone with the check still green.
+- If a firmware edit fails a source anchor, **re-derive the row and rewrite the token** — including
+  when the edit preserved the fact (writing `.freq_hz = 5000` as `5 * 1000`, reordering a Kconfig
+  stanza). Never delete an anchor to make the run green; that removes the evidence instead of
+  refreshing it. See the *Consequences* section of the
+  [target-identity decision record](../meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md).
+- **Quote source in a fenced block, not by indenting it.** Fenced code is exempt; a four-space
+  indented block is **scanned as prose**, so an indented quotation of a superseded wording is
+  reported as a claim. That is deliberate — an indentation-only exemption would also exempt the
+  reflowed middle of a paragraph — and every violation report says so, so you do not have to
+  remember it.
+- Suppressions (`RK-IDENT-SUPPRESSED`) are informational and never fail the run. The fixture suite
+  pins the exact set as `rule|file|suppressor|count`, so adding a suppressed sentence — even under an
+  excuse the baseline already lists — is a review conversation rather than a silent narrowing.
 
 ## Task Management
 

--- a/docs/dev/IMPLEMENTATION_NOTES.md
+++ b/docs/dev/IMPLEMENTATION_NOTES.md
@@ -76,7 +76,9 @@ ui_dispatch_input(UI_INPUT_VOL_UP/DOWN)
 
 **File:** `idf_app/main/platform_display_idf.c`
 
-**Implementation:** CST816D via I2C, integrated with LVGL
+**Implementation:** CST816-family capacitive touch over I2C, integrated with LVGL. The firmware
+reads raw registers rather than binding a variant-specific driver; the fitted marking is
+unverified, so see [board.md](../esp/hw-reference/board.md) rather than asserting a variant.
 
 | Parameter | Value |
 |-----------|-------|
@@ -120,7 +122,7 @@ typedef enum {
 
 | Parameter | Value |
 |-----------|-------|
-| Controller | SH8601 |
+| Panel driver component | `esp_lcd_sh8601` (software component; the panel's driver IC is recorded in [board.md](../esp/hw-reference/board.md)) |
 | Resolution | 360×360 |
 | Interface | QSPI (4-wire) |
 | Color format | RGB565 |
@@ -128,7 +130,7 @@ typedef enum {
 
 **Critical: Byte Order**
 
-The SH8601 expects big-endian RGB565, but ESP32-S3 is little-endian. The flush callback swaps bytes before sending:
+The panel consumes big-endian RGB565, but ESP32-S3 is little-endian. The flush callback swaps bytes before sending:
 
 ```c
 static void lvgl_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
@@ -146,7 +148,7 @@ See [COLORTEST_HELLOWORLD.md](../esp/hw-reference/COLORTEST_HELLOWORLD.md) for d
 **Initialization sequence:**
 1. Initialize SPI bus
 2. Configure LCD panel IO (QSPI)
-3. Load SH8601 init commands
+3. Create the panel with the project's init array (replaces the component's default)
 4. Register LVGL display driver with byte-swap flush callback
 5. Register touch input device
 6. Start LVGL tick timer
@@ -229,7 +231,7 @@ The `platform_*.h` headers define interfaces implemented differently per platfor
 
 | Interface | ESP32-S3 | PC Sim |
 |-----------|----------|--------|
-| `platform_display` | SH8601/QSPI | SDL2 |
+| `platform_display` | `esp_lcd_sh8601`/QSPI | SDL2 |
 | `platform_input` | Encoder + Touch | Keyboard/Mouse |
 | `platform_http` | esp_http_client | libcurl |
 | `platform_storage` | NVS | JSON file |

--- a/docs/dev/testing/TEST_WIFI_ROON_MODE.md
+++ b/docs/dev/testing/TEST_WIFI_ROON_MODE.md
@@ -86,7 +86,9 @@ Happy path test script for WiFi setup and Roon control functionality.
    - Clockwise = scroll down
    - Counter-clockwise = scroll up
 
-4. **Select zone by pressing the knob (center button)**
+4. **Select the zone by tapping it in the list**
+   - The firmware reads no encoder button, so selection is confirmed by touch
+     (see [board.md](../../esp/hw-reference/board.md) for what is and is not wired)
    - Zone picker closes
    - Zone label updates to selected zone name
    - Display shows "Loading zone..."

--- a/docs/esp/DISPLAY.md
+++ b/docs/esp/DISPLAY.md
@@ -1,16 +1,21 @@
 # Display Subsystem
 
-This document covers how the Roon Knob drives its 360×360 pixel AMOLED display using ESP-IDF and LVGL.
+This document covers how the Roon Knob drives its 360×360 pixel display using ESP-IDF and
+LVGL. It owns the driver mechanics; the board's identity — product name, panel technology,
+panel driver IC, colour depth — lives in the canonical record,
+[hw-reference/board.md](hw-reference/board.md).
 
 ## Hardware Overview
 
-| Component | Model | Interface | Notes |
+| Component | Value | Interface | Notes |
 |-----------|-------|-----------|-------|
-| Display controller | SH8601 | QSPI (4-wire) | IPS LCD, 16-bit RGB565 |
+| Panel driver component | `esp_lcd_sh8601` | QSPI (4-wire) | Software component, **not** the panel's driver IC — see [board.md](hw-reference/board.md#panel-controller-versus-software-driver) |
 | Resolution | 360×360 | - | Round display |
-| Backlight | PWM-controlled | GPIO 47 | 8-bit brightness (0-255) |
+| Pixel format | RGB565 | - | `bits_per_pixel = 16`, byte-swapped in the flush callback |
+| Backlight | PWM-controlled | GPIO 47 | LEDC, 8-bit brightness (0-255) |
 
-The SH8601 is an LCD driver IC that accepts pixel data over Quad SPI, allowing faster transfers than standard SPI by using 4 data lines simultaneously.
+Quad SPI carries pixel data over four data lines simultaneously, allowing faster transfers
+than standard SPI.
 
 ## Architecture
 
@@ -36,7 +41,7 @@ The SH8601 is an LCD driver IC that accepts pixel data over Quad SPI, allowing f
 └───────────────────────────┬─────────────────────────────────┘
                             │ SPI DMA transfer
 ┌───────────────────────────▼─────────────────────────────────┐
-│                     SH8601 Display                           │
+│                    360×360 QSPI Panel                        │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -107,11 +112,12 @@ static void lvgl_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px
 }
 ```
 
-The byte-swap is necessary because ESP32 is little-endian but the SH8601 expects big-endian RGB565 pixels.
+The byte-swap is necessary because ESP32 is little-endian but the panel consumes big-endian
+RGB565 pixels.
 
 ### Rounder Callback
 
-The SH8601 requires 2-pixel alignment for memory writes. LVGL's rounder callback adjusts dirty regions:
+The panel requires 2-pixel alignment for memory writes. LVGL's rounder callback adjusts dirty regions:
 
 ```c
 static void lvgl_rounder_cb(lv_event_t *e) {
@@ -141,7 +147,13 @@ esp_lcd_panel_dev_config_t panel_config = {
 esp_lcd_new_panel_sh8601(io_handle, &panel_config, &panel_handle);
 ```
 
-The `vendor_config` contains SH8601-specific initialization commands - a sequence of register writes that configure the display's internal settings (gamma curves, timing, power, etc.).
+The `vendor_config` supplies a panel-specific initialization array — a sequence of register
+writes that configure gamma curves, timing, power, and so on. Passing it **replaces** the
+component's own three-command default; the component still sends standard DCS `MADCTL` and
+`COLMOD` setup before the array, and the project's array overwrites `MADCTL` while `COLMOD`
+stays governed by `bits_per_pixel`. The array itself is Waveshare's own sequence for this
+product. Full analysis and provenance:
+[board.md](hw-reference/board.md#panel-controller-versus-software-driver).
 
 ### Drawing
 
@@ -168,12 +180,12 @@ Used by the sleep manager to power down the display during inactivity.
 The backlight uses PWM (pulse-width modulation) for smooth brightness control:
 
 ```c
-// Configure PWM channel
+// Configure PWM channel (platform_display_idf.c)
 ledc_channel_config_t ledc_channel = {
     .gpio_num = PIN_NUM_BK_LIGHT,
     .speed_mode = LEDC_LOW_SPEED_MODE,
     .channel = LEDC_CHANNEL_0,
-    .duty = 128,  // 50% brightness (0-255)
+    .duty = CONFIG_RK_BACKLIGHT_NORMAL,  // Kconfig default 100 of 255 (~39%)
 };
 ledc_channel_config(&ledc_channel);
 
@@ -182,10 +194,15 @@ ledc_set_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0, new_brightness);
 ledc_update_duty(LEDC_LOW_SPEED_MODE, LEDC_CHANNEL_0);
 ```
 
-The firmware defines brightness levels in Kconfig:
+The firmware defines brightness levels in Kconfig — see
+[KCONFIG.md](../dev/KCONFIG.md#display-sleep-settings-menu) for the defaults and ranges:
 
-- `CONFIG_RK_BACKLIGHT_NORMAL` - Active brightness
-- `CONFIG_RK_BACKLIGHT_DIM` - Dimmed brightness after inactivity
+- `CONFIG_RK_BACKLIGHT_NORMAL` - Active brightness, default 100 of 255 (≈ 39 %)
+- `CONFIG_RK_BACKLIGHT_DIM` - Dimmed brightness after inactivity, default 25 of 255 (≈ 10 %)
+
+The comment above the LEDC setup in `platform_display_idf.c` still says 50 %. It is stale: the
+initial duty has come from `CONFIG_RK_BACKLIGHT_NORMAL` since that option was introduced, and
+no 128 literal exists in the file.
 
 ## Display Sleep Management
 
@@ -224,7 +241,7 @@ Thread safety is handled via a FreeRTOS mutex - timer callbacks set pending flag
 1. **Backlight PWM** - Configure LEDC timer and channel
 2. **SPI bus** - Initialize QSPI with DMA
 3. **Panel IO** - Create SPI panel IO handle
-4. **Panel driver** - Initialize SH8601 with vendor commands
+4. **Panel driver** - Create the panel via `esp_lcd_new_panel_sh8601()` with the project's init array
 5. **Panel reset** - Hardware reset via GPIO
 6. **I2C bus** - For touch controller (separate from display)
 7. **Touch controller** - CST816 initialization

--- a/docs/esp/DUAL_CHIP_ARCHITECTURE.md
+++ b/docs/esp/DUAL_CHIP_ARCHITECTURE.md
@@ -2,14 +2,22 @@
 
 > **Note**: Bluetooth mode was removed from this project. The secondary ESP32 chip is unused. This documentation is kept as reference for the Waveshare board's hardware capabilities.
 
-The Waveshare ESP32-S3-Knob-Touch-LCD-1.8 board contains **two separate ESP32 chips** that communicate via UART. This enables capabilities not possible with either chip alone.
+The Waveshare ESP32-S3-Knob-Touch-LCD-1.8 board contains **two separate ESP32 SoCs** that communicate via UART. This enables capabilities not possible with either chip alone.
+
+Board identity facts (exact part numbers, memory sizes, what is vendor-declared versus still
+unverified) live in the canonical record: [hw-reference/board.md](hw-reference/board.md). This
+document owns the two-SoC topology, the UART link, and the protocol.
 
 ## Hardware Overview
 
-| Chip | Model | Bluetooth | Primary Role |
-|------|-------|-----------|--------------|
-| ESP32-S3 | ESP32-S3-WROOM-1 (R8) | BLE 5.0 only | Display, Touch, WiFi, BLE HID |
-| ESP32 | ESP32-WROOM | Classic BT + BLE | Audio DAC, AVRCP, A2DP |
+Roles and radio capability only. Part numbers, package, memory and flash sizes are **not**
+restated here — they are in the
+[canonical record's identity summary](hw-reference/board.md#identity-summary).
+
+| SoC | Bluetooth | Primary Role |
+|-----|-----------|--------------|
+| Primary (the one this firmware runs on) | BLE 5.0 only | Display, Touch, WiFi, BLE HID |
+| Secondary (unused by this firmware) | Classic BT + BLE | Audio DAC, AVRCP, A2DP |
 
 ## Why Two Chips?
 
@@ -65,9 +73,9 @@ To switch programming target:
 ## Peripheral Connections
 
 ### ESP32-S3 Peripherals
-- **Display**: SH8601 AMOLED via QSPI
-- **Touch**: CST816 via I2C
-- **Rotary Encoder**: Quadrature input
+- **Display**: 360×360 QSPI panel (see [board.md](hw-reference/board.md))
+- **Touch**: capacitive touch via I2C
+- **Rotary Encoder**: Quadrature input on GPIO 8 / GPIO 7 — the one this firmware reads
 - **WiFi**: 2.4GHz 802.11 b/g/n
 - **BLE**: Bluetooth 5.0 LE
 
@@ -77,7 +85,10 @@ To switch programming target:
   - `ESP32_I2S_DAC_DIN` - Data in
   - `ESP32_I2S_DAC_LRCK` - Left/Right clock
 - **Classic Bluetooth**: BR/EDR for A2DP/AVRCP
-- **Rotary Encoder**: Second encoder input (board has dual encoders)
+- **Rotary Encoder**: Waveshare declares a second encoder "acting on ESP32S3 and ESP32
+  respectively". Whether it is populated and reachable is **unverified** on the owned device,
+  and no code in this repository reads it — see
+  [board.md](hw-reference/board.md#still-requires-physical-inspection).
 
 ### Shared/Other
 - **DRV2605**: Haptic driver via I2C

--- a/docs/esp/ROTARY_ENCODER.md
+++ b/docs/esp/ROTARY_ENCODER.md
@@ -1,6 +1,10 @@
 # Rotary Encoder Input
 
-This document covers how the firmware reads the physical knob (rotary encoder) and translates rotation into volume control.
+This document covers how the firmware reads the physical knob (rotary encoder) and translates
+rotation into volume control. How many encoders the board has, and whether the shaft carries a
+switch, are identity questions answered in
+[hw-reference/board.md](hw-reference/board.md) — this firmware reads rotation only, on GPIO 8
+and GPIO 7.
 
 ## Hardware Overview
 

--- a/docs/esp/TOUCH_INPUT.md
+++ b/docs/esp/TOUCH_INPUT.md
@@ -1,16 +1,18 @@
 # Touch Input
 
-This document covers capacitive touch input using the CST816S controller.
+This document covers capacitive touch input and its LVGL integration. The exact touch
+controller part, and what about it is still unverified, is recorded in
+[hw-reference/board.md](hw-reference/board.md).
 
 ## Hardware Overview
 
-| Component | Model | Interface | Address |
+| Component | Value | Interface | Address |
 |-----------|-------|-----------|---------|
-| Touch controller | CST816 | I2C | 0x15 |
+| Touch controller | CST816 family (see [board.md](hw-reference/board.md)) | I2C | 0x15 |
 | I2C SDA | GPIO 11 | - | - |
 | I2C SCL | GPIO 12 | - | - |
 
-The CST816 is a single-point capacitive touch controller commonly found in smartwatch displays. It reports touch coordinates over I2C when the user touches the screen.
+CST816-family parts are single-point capacitive touch controllers commonly found in smartwatch displays. They report touch coordinates over I2C when the user touches the screen.
 
 ## Architecture
 
@@ -27,7 +29,7 @@ The CST816 is a single-point capacitive touch controller commonly found in smart
                             │ tpGetCoordinates()
 ┌───────────────────────────▼─────────────────────────────────┐
 │                    lcd_touch_bsp.c                           │
-│              CST816S I2C register reads                      │
+│           raw I2C register reads (7 bytes @ 0x00)            │
 └───────────────────────────┬─────────────────────────────────┘
                             │ i2c_read_buff()
 ┌───────────────────────────▼─────────────────────────────────┐
@@ -36,7 +38,7 @@ The CST816 is a single-point capacitive touch controller commonly found in smart
 └───────────────────────────┬─────────────────────────────────┘
                             │
 ┌───────────────────────────▼─────────────────────────────────┐
-│                  CST816S Touch IC                            │
+│              CST816-family touch IC @ 0x15                   │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -63,9 +65,11 @@ Devices on this bus:
 
 The bus runs at 300kHz, which is within spec for both devices.
 
-## CST816S Register Map
+## Touch Register Map
 
-The touch controller uses a simple register interface. Reading 7 bytes from register 0x00 gives:
+The touch controller uses a simple register interface, documented in the CST816D datasheet
+Waveshare links and shared across the CST816 variants this firmware could be sitting on.
+Reading 7 bytes from register 0x00 gives:
 
 | Byte | Content |
 |------|---------|

--- a/docs/esp/hw-reference/COLORTEST_HELLOWORLD.md
+++ b/docs/esp/hw-reference/COLORTEST_HELLOWORLD.md
@@ -1,17 +1,19 @@
-# SH8601 QSPI Display Color Configuration (LVGL 9)
+# Display Color Configuration — RGB565 byte order (LVGL 9)
 
-This document describes the correct color configuration for the Waveshare ESP32-S3 Touch AMOLED 1.8" display with SH8601 controller using LVGL 9.
+This document owns one thing: the RGB565 byte order and LVGL 9 colour-format settings that
+make colours render correctly over the QSPI panel. For the board's identity — product name,
+panel technology, panel driver IC, colour depth — see [board.md](board.md).
 
 ## The Problem
 
-Colors appear shifted/wrong on the SH8601 QSPI display. Common symptoms:
+Colors appear shifted/wrong on the QSPI panel. Common symptoms:
 - Red appears as a different color
 - Green/blue channels seem swapped or mixed
 - Test patterns show wrong colors but UI elements render
 
 ## Root Cause: Byte Order Mismatch
 
-The SH8601 QSPI display expects **big-endian RGB565** data, but:
+The panel consumes **big-endian RGB565** data over QSPI, but:
 - ESP32-S3 is **little-endian**
 - LVGL 9 renders in native (little-endian) RGB565
 
@@ -23,7 +25,8 @@ The correct approach is to swap bytes in the LVGL flush callback before sending 
 
 ### Flush Callback Implementation
 
-In `platform_display_idf.c`:
+Adapted from `platform_display_idf.c` (the stale controller attribution in the source
+comment is replaced here with transport-neutral wording):
 
 ```c
 static void lvgl_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
@@ -34,7 +37,7 @@ static void lvgl_flush_cb(lv_display_t *disp, const lv_area_t *area, uint8_t *px
     const int offsety1 = area->y1;
     const int offsety2 = area->y2;
 
-    // Swap bytes for big-endian QSPI display (SH8601 expects big-endian RGB565)
+    // Swap bytes for the panel transport's big-endian RGB565 byte order
     // ESP32 is little-endian, so we need to swap each 16-bit pixel
     const int width = offsetx2 - offsetx1 + 1;
     const int height = offsety2 - offsety1 + 1;
@@ -75,7 +78,9 @@ img_dsc.header.cf = LV_COLOR_FORMAT_RGB565;  // Standard format
 
 ## Panel Configuration
 
-Standard SH8601 configuration:
+The panel-device configuration handed to the driver component — note that `bits_per_pixel`,
+not the init array, is what selects the pixel format
+(see [board.md](board.md#panel-controller-versus-software-driver)):
 
 ```c
 const esp_lcd_panel_dev_config_t panel_config = {
@@ -111,7 +116,7 @@ Call it from `ui_init()` to verify colors are correct, then remove the call.
 
 | Component | Format | Notes |
 |-----------|--------|-------|
-| Display driver | Standard RGB565 | No special color format setting |
+| Panel driver | Standard RGB565 | No special color format setting |
 | Flush callback | Byte swap | Swaps each 16-bit pixel before send |
 | JPEG decoder | `JPEG_PIXEL_FORMAT_RGB565_LE` | Little-endian, flush swaps it |
 | Image descriptors | `LV_COLOR_FORMAT_RGB565` | Standard format |

--- a/docs/esp/hw-reference/HARDWARE_PINS.md
+++ b/docs/esp/hw-reference/HARDWARE_PINS.md
@@ -1,8 +1,10 @@
 # Hardware Pin Configuration
 
-GPIO pin assignments for the Waveshare ESP32-S3 Touch AMOLED 1.8" (360×360).
+GPIO pin assignments as this firmware configures them. For the board's identity — product
+name, panel technology, panel driver IC, colour depth, memory sizes — see the canonical
+record: [board.md](board.md). This file owns only the pin assignments.
 
-## Display Pins (SH8601 AMOLED via QSPI)
+## Display Pins (QSPI)
 
 | Function | GPIO | Notes |
 |----------|------|-------|
@@ -13,9 +15,10 @@ GPIO pin assignments for the Waveshare ESP32-S3 Touch AMOLED 1.8" (360×360).
 | LCD_DATA2 | 17 | QSPI Data 2 |
 | LCD_DATA3 | 18 | QSPI Data 3 |
 | LCD_RST | 21 | Reset line |
-| BK_LIGHT | 47 | Backlight (always on for AMOLED) |
+| BK_LIGHT | 47 | Backlight, LEDC PWM, 8-bit duty; initial value `CONFIG_RK_BACKLIGHT_NORMAL` (Kconfig default 100 of 255, ≈ 39 %) |
 
-**Display:** 360×360 round AMOLED with SH8601 controller using 4-wire QSPI interface.
+**Display:** 360×360 round panel over a 4-wire QSPI interface. Panel technology and driver IC
+are recorded in [board.md](board.md).
 
 ## Input Pins
 
@@ -32,9 +35,11 @@ GPIO pin assignments for the Waveshare ESP32-S3 Touch AMOLED 1.8" (360×360).
 - Internal pull-ups enabled
 - Generates UI_INPUT_VOL_UP/VOL_DOWN events
 
-**Note:** This device has NO physical buttons. The encoder shaft is NOT pressable. All button-like interactions use the touchscreen.
+**Note:** This firmware reads no physical button on any GPIO — all button-like interactions go
+through the touchscreen. Whether the encoder shaft has a switch fitted is unconfirmed on the
+owned device; see [board.md](board.md#still-requires-physical-inspection).
 
-### Touch Controller (CST816D)
+### Touch Controller
 
 | Function | GPIO | I2C Details |
 |----------|------|-------------|
@@ -48,9 +53,10 @@ GPIO pin assignments for the Waveshare ESP32-S3 Touch AMOLED 1.8" (360×360).
 | Resolution | 12-bit (0-4095 raw → 0-359 display) |
 
 **Implementation:**
-- CST816D capacitive touch controller
+- Raw 7-byte register read at address `0x15` (see `idf_app/components/lcd_touch_bsp/`)
 - Integrated with LVGL as `LV_INDEV_TYPE_POINTER`
 - Touch events handled automatically by LVGL input system
+- Exact touch controller part: see [board.md](board.md)
 
 ## Battery Monitoring (ADC)
 
@@ -84,6 +90,6 @@ Be cautious with these ESP32-S3 pins:
 
 ## Implementation Files
 
-- `idf_app/main/platform_display_idf.c` - Display pin definitions and SH8601 init
+- `idf_app/main/platform_display_idf.c` - Display pin definitions and panel init sequence
 - `idf_app/main/platform_input_idf.c` - Encoder GPIO and polling
 - `idf_app/main/platform_battery_idf.c` - Battery ADC configuration

--- a/docs/esp/hw-reference/RGB565_IMPLEMENTATION.md
+++ b/docs/esp/hw-reference/RGB565_IMPLEMENTATION.md
@@ -39,7 +39,7 @@ Firmware now receives artwork as raw RGB565 data from the bridge instead of JPEG
 2. **Validate** - Check size matches expected (360×360×2)
 3. **Copy** - memcpy to global PSRAM buffer (ui_jpeg.c:191)
 4. **Display** - LVGL descriptor points to buffer
-5. **Byte swap** - Display flush callback converts to big-endian for SH8601 QSPI (platform_display_idf.c:329-333)
+5. **Byte swap** - Display flush callback converts to big-endian for the QSPI panel (platform_display_idf.c:329-333)
 
 ### Code Locations
 
@@ -51,7 +51,7 @@ Firmware now receives artwork as raw RGB565 data from the bridge instead of JPEG
 ## Byte Order
 
 **Bridge sends:** Little-endian RGB565
-**Display expects:** Big-endian RGB565 (SH8601 QSPI)
+**Panel consumes:** Big-endian RGB565 over QSPI (see [board.md](board.md))
 **Handled by:** Flush callback swaps bytes before sending to display
 
 ## Error Handling

--- a/docs/esp/hw-reference/board.md
+++ b/docs/esp/hw-reference/board.md
@@ -1,55 +1,448 @@
-# Waveshare ESP32-S3 Touch AMOLED 1.8" – Board Overview
+# Waveshare ESP32-S3-Knob-Touch-LCD-1.8 — Canonical Target Identity Record
 
-## Summary
+**This file is the single canonical identity and provenance record for the shipping round
+target.** Other documents must not independently restate product identity, panel type, panel
+controller, colour depth, backlight, touch part, memory sizes, or encoder/button facts. They
+link here instead and keep only the facts they genuinely own (pin tables, driver mechanics,
+UI behaviour, porting steps).
 
-- **MCU:** ESP32-S3 dual-core @ 240 MHz
-- **Wireless:** 2.4 GHz Wi-Fi (802.11 b/g/n) + Bluetooth 5 (LE)
-- **Memory:** 16 MB Flash + 8 MB PSRAM (octal)
-- **Display:** 1.8" round AMOLED, 360×360, 16.7M colors
-- **Display Controller:** SH8601 via QSPI
-- **Touch:** CST816D capacitive touch via I2C
-- **Input:** Rotary encoder (quadrature, no push button)
-- **Power:** LiPo battery support with charging
+Issue [#211](https://github.com/muness/roon-knob/issues/211) created this record. Decision
+record: [2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md](../../meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md).
 
-## Key Specs
+This file has no blanket exemption from the regression checker. Its current-fact sections are
+scanned exactly like every other document, so mutating a live row of the identity table below
+fails CI. Only the [Historical claims](#historical-claims-now-superseded) section is exempt, and
+only because restating superseded claims is that section's whole purpose.
 
-| Feature | Specification |
-|---------|---------------|
-| MCU | ESP32-S3-WROOM-1 (dual-core Xtensa LX7) |
-| Clock | Up to 240 MHz |
-| Flash | 16 MB (quad SPI) |
-| PSRAM | 8 MB (octal SPI) |
-| SRAM | 512 KB internal |
-| Display | 360×360 AMOLED, SH8601 controller |
-| Display Interface | QSPI (4-wire SPI with quad data) |
-| Touch | CST816D, I2C @ 0x15 |
-| Encoder | EC11-style quadrature (rotation only) |
-| USB | USB-C (native USB for programming/serial) |
+---
 
-## What Matters for Firmware
+## How to read this record
 
-### Display
-- 360×360 SH8601 AMOLED over QSPI
-- Requires byte-swapped RGB565 (big-endian) - handled in flush callback
-- No PWM backlight control needed (AMOLED is self-emitting)
+Every fact below carries a provenance class. Nothing is stated without one.
 
-### Touch
-- CST816D on I2C (GPIO 11/12)
-- 12-bit coordinate resolution
-- Integrated with LVGL as pointer input device
+| Class | Meaning | What it does *not* mean |
+|-------|---------|-------------------------|
+| **V — Vendor-declared** | Waveshare's own product page, wiki, or shipped demo sources say it | That we have measured it on the owned device |
+| **R — Repository-observed** | This repository's source code does it, and the file/line is cited | That the hardware requires it, or that it is optimal |
+| **A — Artifact-observed** | Read out of an immutable published release binary | That the value is correct for the physical flash |
+| **H — Historical** | A previously published claim in this repository, now superseded | That it was ever true |
+| **U — Physically unverified** | Requires the owned device (`esptool`, visual inspection, meter) | That it is doubted — only that nobody here has looked |
 
-### Input
-- Rotary encoder on GPIO 7/8 for volume control
-- **No physical buttons** - use touch for play/pause, menus
+**No claim in this file is based on physical inspection of an owned device.** Section
+[Still requires physical inspection](#still-requires-physical-inspection) lists what is
+therefore still open, and no `U` fact is treated anywhere as if it were verified.
 
-### Memory
-- 8 MB PSRAM allows generous LVGL buffers
-- DMA-capable internal RAM for display transfers
-- PSRAM for artwork caching, network buffers
+---
 
-## Related Docs
+## Identity summary
 
-- Pin assignments: [HARDWARE_PINS.md](HARDWARE_PINS.md)
-- Touch controller: [cst816d.md](cst816d.md)
-- Rotary encoder: [encoder.md](encoder.md)
-- Display colors: [COLORTEST_HELLOWORLD.md](COLORTEST_HELLOWORLD.md)
+| Fact | Value | Class |
+|------|-------|-------|
+| Product | Waveshare **ESP32-S3-Knob-Touch-LCD-1.8** | V, R |
+| Primary SoC | **ESP32-S3R8** (Xtensa LX7 dual-core, up to 240 MHz, 8 MB in-package PSRAM) | V |
+| Secondary SoC | **ESP32-U4WDH** (4 MB in-package flash) | V |
+| External flash | 16 MB | V |
+| PSRAM | 8 MB | V |
+| SRAM / ROM | 512 KB SRAM, 384 KB ROM | V |
+| Panel technology | **IPS LCD** (the superseded panel-technology claim is listed under [Historical claims](#historical-claims-now-superseded)) | V |
+| Panel size / resolution | 1.8 in round, 360 × 360 | V |
+| Panel colour depth | **262 K colours** | V |
+| Panel brightness / contrast | 600 cd/m², 1200:1 | V |
+| Panel interface | QSPI | V, R |
+| Panel driver IC | **ST77916** | V |
+| Software panel driver used | `esp_lcd_sh8601` managed component | R |
+| Backlight | **PWM-controlled, GPIO 47**; initial duty is `CONFIG_RK_BACKLIGHT_NORMAL`, Kconfig default 100 of 255 (≈ 39 %) | V, R |
+| Touch controller | **CST816** (vendor-linked datasheet is `CST816D_datasheet_En_V1.3.pdf`) | V |
+| Touch bus | I²C, 7-bit address `0x15` | V, R |
+| Encoders | Vendor declares **two**; this firmware drives **one** (GPIO 8 / GPIO 7) | V, R |
+| Encoder push switch | None wired as far as this firmware is concerned; shaft switch presence on the owned unit unconfirmed | R, U |
+| Audio DAC | PCM5100A over I²S (unused by this firmware) | V |
+| Haptics | DRV2605 over I²C | V |
+| USB routing | CH445P analog switch shares one USB-C port between the two SoCs | V |
+
+The Product row deliberately carries both **V** and **R**. Waveshare supplies the product
+name; the repository binding is an inference from repository-observed convergence with that
+product's shipped demo: the 185-entry project panel-init array is byte-for-byte identical to
+the demo array, and the implemented QSPI/backlight mapping matches the vendor sources cited
+below. This binds the repository target, not the physical revision of an owned unit. Revision
+silkscreen and fitted-part markings remain **U** until #189 records them.
+
+---
+
+## Vendor-declared facts
+
+Primary sources, both retrieved 2026-07-30:
+
+- Product page — <https://www.waveshare.com/esp32-s3-knob-touch-lcd-1.8.htm>
+- Wiki — <https://www.waveshare.com/wiki/ESP32-S3-Knob-Touch-LCD-1.8>
+- Demo archive — <https://files.waveshare.com/wiki/ESP32-S3-Knob-Touch-LCD-1.8/ESP32-S3-Knob-Touch-LCD-1.8-Demo.zip>
+  (68 704 748 bytes, `sha256:11e382444fe93470fbe463829c1e0ebad5bdb5115fd2d72f6159cd7700015030`)
+
+### Display, quoted from the product page's own specification block
+
+> display panel **IPS** · display size **1.8 inch** · resolution **360 × 360** ·
+> display color **262K** · brightness **600cd/m²** · contrast ratio **1200:1** ·
+> Communication interface **QSPI** · Driver IC **ST77916** · Touch Type **Capacitive** ·
+> Touch IC **CST816**
+
+The product page and the wiki also carry panel wording that does **not** belong to this board.
+It appears in cross-sell tables for other Waveshare products and in tutorial screenshots reused
+from a different product's wiki, and it is the most likely origin of the superseded identity
+described under [Historical claims](#historical-claims-now-superseded).
+
+The other product concerned, named here so the confusion is traceable:
+
+<!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-AMOLED-1.91" reason="truthful fact about a different Waveshare product whose wiki screenshots were reused on this product's page; naming it is what makes the origin of the superseded claim traceable" -->
+- ESP32-S3-AMOLED-1.91 — a separate Waveshare product with its own panel technology and its own
+  driver IC. Nothing on its wiki is a statement about the round knob board.
+
+### Wiki "Onboard Resources", quoted
+
+> 1. **ESP32-S3R8** — Wi-Fi and Bluetooth SoC, 240MHz operating frequency, with 8MB PSRAM
+> 2. **ESP32-U4WDH** — Wi-Fi and classic Bluetooth, 240MHz operating frequency, with 4MB Flash
+> 3. **PCM5100A** — High-performance stereo DAC using I2S interface
+> 5. **16MB Flash** — Expanded 16MB Flash
+> 6. **Dual encoder** — Acting on ESP32S3 and ESP32 respectively
+> 8. **DRV2605** — Vibration motor driver, using I2C interface
+> 9. **CH445P** — Four-pole double-throw 3.3V low resistance analog switch chip
+
+The wiki also states "Built-in 512KB SRAM, 384KB ROM, 16MB Flash and 8MB PSRAM" and
+describes the product as having "a built-in 1.8inch **LCD** screen".
+
+The wiki's separately listed buttons are a **Power button** and an **ESP32-S3R8 BOOT
+button**. The wiki does not describe an encoder shaft switch either way.
+
+### Backlight, from the vendor's own demo sources
+
+`ESP-IDF/08_LVGL_Test/main/user_config.h`:
+
+```c
+#define EXAMPLE_PIN_NUM_BK_LIGHT    (gpio_num_t)47
+```
+
+`ESP-IDF/08_LVGL_Test/components/lcd_bl_pwm_bsp/lcd_bl_pwm_bsp.c` configures an LEDC timer
+at `.duty_resolution = LEDC_TIMER_8_BIT`, `.freq_hz = 50 * 1000` on that pin, and exposes
+`setUpduty()`. The vendor demo also offers a `Backlight_Testing` build switch.
+
+A vendor-supplied PWM backlight on GPIO 47 is consistent with an LCD, and inconsistent with the
+superseded panel-technology claim listed under
+[Historical claims](#historical-claims-now-superseded).
+
+### Touch and display pins, from the vendor's `user_config.h`
+
+`LCD_CS 14 · LCD_PCLK 13 · LCD_DATA0..3 15/16/17/18 · LCD_RST 21 · BK_LIGHT 47` ·
+`TOUCH_ADDR 0x15 · TOUCH_RST 10 · TOUCH_INT 9 · SDA 11 · SCL 12` ·
+`EXAMPLE_LCD_H_RES 360 · EXAMPLE_LCD_V_RES 360`.
+
+### The vendor drives this LCD through `esp_lcd_sh8601` too
+
+`ESP-IDF/08_LVGL_Test/main/idf_component.yml`:
+
+```yaml
+dependencies:
+  esp_lcd_sh8601:
+    version: '*'
+    public: true
+```
+
+This is the decisive reason the component name is not a controller claim: Waveshare declares
+a **ST77916** driver IC on the same page from which it ships a demo that binds the panel
+through the **`esp_lcd_sh8601`** software component. See
+[Panel controller versus software driver](#panel-controller-versus-software-driver).
+
+---
+
+## Repository-observed facts
+
+| Fact | Evidence |
+|------|----------|
+| QSPI pins `CS 14 · PCLK 13 · D0-D3 15/16/17/18 · RST 21` | `idf_app/main/platform_display_idf.c:55` – `:61` |
+| Backlight on GPIO 47 driven by LEDC PWM, `LEDC_TIMER_8_BIT` resolution at 5 kHz | `idf_app/main/platform_display_idf.c:62`, `:457` – `:464` |
+| Initial backlight duty is `CONFIG_RK_BACKLIGHT_NORMAL`, whose Kconfig default is 100 of 255 (≈ 39 %) | `idf_app/main/platform_display_idf.c:471` sets `.duty = CONFIG_RK_BACKLIGHT_NORMAL`; `idf_app/main/Kconfig.projbuild:35` – `:41` declares `default 100`, `range 0 255`, help text "approximately 40% brightness"; [../../dev/KCONFIG.md](../../dev/KCONFIG.md) already documented 100 (~40 %) |
+| The stale comment at `idf_app/main/platform_display_idf.c:456` says the initial backlight duty is 50 %. The channel configuration at `:471` reads the Kconfig value; no `128` literal exists in the file, and no code path implements that stale 50 % claim. Values, not comments, are the evidence for the row above | `idf_app/main/platform_display_idf.c:456` – `:474` |
+| Panel bound via `esp_lcd_new_panel_sh8601()` with `bits_per_pixel = 16` and a project-supplied `init_cmds` array | `idf_app/main/platform_display_idf.c:496` – `:514` |
+| Project init array is 185 entries, 146 distinct opcodes, ends with `{0x36, {0x00}, 1, 0}` | `idf_app/main/platform_display_idf.c:65` – `:251` |
+| The comment at `idf_app/main/platform_display_idf.c:329` attributes the panel's big-endian RGB565 byte order to the SH8601-named component. It is **stale**: the byte swap proves the transport's byte order, not the physical controller identity | `idf_app/main/platform_display_idf.c:319` – `:336`; vendor/controller evidence in [Panel controller versus software driver](#panel-controller-versus-software-driver) |
+| Exactly one encoder: channel A on GPIO 8, channel B on GPIO 7, 3 ms software-polled quadrature with 2-tick debounce | `idf_app/main/platform_input_idf.c:27` – `:28`, `:38` – `:39` |
+| No physical button is read anywhere in the firmware | Derived from what the code does, not from any comment: `gpio_config()` is called exactly twice, at `idf_app/main/platform_input_idf.c:74` and `:84`, for `ENCODER_GPIO_A` and `ENCODER_GPIO_B` only; `gpio_get_level()` appears only at `:87` – `:88` and `:120` – `:121`, on those same two pins; no other GPIO is configured as an input or sampled anywhere in `idf_app/` or `common/` |
+| The comment at `idf_app/main/platform_input_idf.c:31` says the device has no physical buttons. It is **stale**: the code proves only that this firmware reads no button; whether an encoder shaft switch is fitted remains physically unverified | `idf_app/main/platform_input_idf.c:27` – `:39`; repository-wide input-use derivation in the row above |
+| Touch is a raw 7-byte register read at I²C `0x15`, not a CST816-specific component | `idf_app/components/lcd_touch_bsp/lcd_touch_bsp.c`, `idf_app/components/i2c_bsp/i2c_bsp.c` |
+| The touch BSP is a whitespace-reformatted copy of Waveshare's `lcd_touch_bsp.c` — identical logic | diff against the demo archive's `ESP-IDF/08_LVGL_Test/components/lcd_touch_bsp/lcd_touch_bsp.c` |
+| The panel consumes big-endian RGB565; the flush callback swaps each 16-bit pixel | `idf_app/main/platform_display_idf.c` flush callback; see [COLORTEST_HELLOWORLD.md](COLORTEST_HELLOWORLD.md) |
+| Zone picker opens on a **touch click of the zone header**, and on no encoder input | `common/ui.c:389` registers `zone_label_event_cb` on `LV_EVENT_CLICKED`; that callback at `common/ui.c:542` – `:552` is the **only** emitter of `UI_INPUT_MENU`, handled at `common/bridge_client.c:954` – `:961`. The default zone label text is literally `"Tap here to select zone"` (`common/bridge_client.c:862`) |
+| `esp_lcd_sh8601` is declared with `version: '*'` — unpinned | `idf_app/main/idf_component.yml` |
+
+Managed-component pinning and a committed dependency lock are **not** decided here; that
+acceptance criterion belongs to [#203](https://github.com/muness/roon-knob/issues/203).
+
+---
+
+## Panel controller versus software driver
+
+The precise, supported statement — no more, no less:
+
+1. **The project replaces the component's vendor-specific initialisation array.**
+   `esp_lcd_sh8601` (2.0.1~1) declares its own three-command
+   `vendor_specific_init_default[]` = `{0x44, {0x00,0xC8}}`, `{0x35, {0x00}}`,
+   `{0x53, {0x20}}`. Because the project passes `vendor_config.init_cmds`, that default is
+   **not** sent at all — `panel_sh8601_init()` selects one array or the other, never both.
+
+2. **The component still sends standard DCS setup before the array.**
+   `panel_sh8601_init()` transmits `LCD_CMD_MADCTL` (`0x36`) and then `LCD_CMD_COLMOD`
+   (`0x3A`) from its cached values *before* iterating the chosen array. So the panel receives
+   standard DCS setup regardless of what the project supplies.
+
+3. **The project's array overwrites MADCTL.** Its final entry is `{0x36, {0x00}, 1, 0}`. The
+   component detects this, logs *"The 36h command has been used and will be overwritten by
+   external initialization sequence"*, updates its cached `madctl_val`, and sends the
+   project's value. The project's MADCTL therefore wins.
+
+4. **COLMOD remains governed by the panel config.** The project's array contains **no**
+   `0x3A`. `colmod_val` stays whatever `esp_lcd_new_panel_sh8601()` derived from
+   `panel_dev_config.bits_per_pixel`; at the project's `bits_per_pixel = 16` that is `0x55`
+   (RGB565). Changing the pixel format is a panel-config edit, not an init-array edit.
+
+### Structural comparison — reproducible
+
+Measured 2026-07-30 with Python's `difflib` over the opcode sequences:
+
+| Comparison | Result |
+|---|---|
+| Project array vs Waveshare demo `lcd_init_cmds[]`, default (`EXAMPLE_Rotate_90` undefined) branch | **Byte-for-byte identical**, 185/185 entries |
+| Project array vs `esp_lcd_st77916` 2.0.2 `esp_lcd_st77916_spi.c` `vendor_specific_init_default[]` (216 entries) | opcode-sequence similarity **0.8928**; **179 of 185** project opcodes fall inside common blocks; longest equal run **175**; payloads identical at **84 of 179** (46.9 %) |
+| Project array vs `esp_lcd_sh8601` 2.0.1~1 `vendor_specific_init_default[]` (3 entries) | opcode overlap **zero** |
+| `esp_lcd_st77916` default vs `esp_lcd_sh8601` default | opcode overlap **zero** |
+
+Reproduce. Prerequisites: network access, `bash`, Python 3, and the host tools `curl`,
+`shasum` and `unzip`. Only the *analysis* is Python-3-standard-library-only — it imports
+nothing but `difflib`, `os` and `re`. Edit the first line to point at your own checkout of
+this repository; everything after it is copy-pasteable as written:
+
+```bash
+REPO=/path/to/roon-knob            # <-- your checkout of this repository
+export REPO
+
+mkdir -p /tmp/rk-panel && cd /tmp/rk-panel
+
+curl -sSL -o sh8601.zip \
+  'https://components-file.espressif.com/components/espressif/esp_lcd_sh8601/2.0.1~1/espressif__esp_lcd_sh8601-v2.0.1_1.zip'
+curl -sSL -o st77916.zip \
+  'https://components-file.espressif.com/components/espressif/esp_lcd_st77916/2.0.2/espressif__esp_lcd_st77916-v2.0.2.zip'
+curl -sSL -A 'Mozilla/5.0' -o knobdemo.zip \
+  'https://files.waveshare.com/wiki/ESP32-S3-Knob-Touch-LCD-1.8/ESP32-S3-Knob-Touch-LCD-1.8-Demo.zip'
+
+shasum -a 256 sh8601.zip st77916.zip knobdemo.zip
+# 0807c6439c1a91199f34dfd8fc6ff994964d8e2b589be06a2a19faeb317015ae  sh8601.zip
+# e31f466ea9759eddbda3e89756f068e34f7f6ef1698925def508e7f8b2cc2696  st77916.zip
+# 11e382444fe93470fbe463829c1e0ebad5bdb5115fd2d72f6159cd7700015030  knobdemo.zip
+
+for z in sh8601 st77916 knobdemo; do unzip -qo "$z.zip" -d "$z"; done
+
+python3 - <<'PY'
+import difflib, os, re
+def parse(path, name, typ):
+    src = open(path, encoding='utf-8', errors='replace').read()
+    body = re.search(r'static\s+const\s+%s\s+%s\s*\[\s*\]\s*=\s*\{(.*?)\n\}\s*;'
+                     % (typ, name), src, re.S).group(1)
+    return [(int(m.group(1), 16),
+             tuple(int(x, 16) for x in re.findall(r'0x[0-9A-Fa-f]+', m.group(2))))
+            for m in re.finditer(r'\{\s*(0x[0-9A-Fa-f]+)\s*,\s*\(uint8_t\s*\[\]\s*\)'
+                                 r'\s*\{([^}]*)\}\s*,\s*(\d+)\s*,\s*(\d+)\s*\}', body)]
+repo = os.environ['REPO']
+P = parse(repo + '/idf_app/main/platform_display_idf.c', 'lcd_init_cmds', 'sh8601_lcd_init_cmd_t')
+W = parse('knobdemo/ESP32-S3-Knob-Touch-LCD-1.8-Demo/ESP-IDF/08_LVGL_Test/main/main.c',
+          'lcd_init_cmds', 'sh8601_lcd_init_cmd_t')
+S = parse('st77916/esp_lcd_st77916_spi.c', 'vendor_specific_init_default', 'st77916_lcd_init_cmd_t')
+H = parse('sh8601/esp_lcd_sh8601.c', 'vendor_specific_init_default', 'sh8601_lcd_init_cmd_t')
+Wdef = [e for e in W if e != (0x36, (0x60,))]          # drop the EXAMPLE_Rotate_90 branch
+ops = lambda e: [c for c, _ in e]
+print('project entries          :', len(P))
+print('project == vendor default:', P == Wdef)
+sm = difflib.SequenceMatcher(a=ops(P), b=ops(S), autojunk=False)
+eq = [(i1, i2, j1) for t, i1, i2, j1, _ in sm.get_opcodes() if t == 'equal']
+n = sum(i2 - i1 for i1, i2, _ in eq)
+same = sum(1 for i1, i2, j1 in eq for k in range(i2 - i1) if P[i1 + k][1] == S[j1 + k][1])
+print('vs st77916 similarity    : %.4f' % sm.ratio())
+print('matched opcodes / longest: %d of %d / %d' % (n, len(P), max(i2 - i1 for i1, i2, _ in eq)))
+print('identical payloads       : %d of %d' % (same, n))
+print('overlap with sh8601 dflt :', sorted(set(ops(P)) & set(ops(H))))
+print('project has 0x36 / 0x3A  :', 0x36 in ops(P), '/', 0x3A in ops(P))
+PY
+```
+
+`esp_lcd_sh8601` 2.0.1 and 2.0.1~1 differ only in the `commit_sha` and `version` fields of
+`idf_component.yml`; the C source is identical, so the conclusion does not depend on which
+of the two a build resolves.
+
+### What this does and does not establish
+
+**Supported.** The panel's initialisation sequence is the vendor's own sequence for this
+exact product, and it is structurally an ST77916-family sequence: page-switched command sets
+(`0xF0`/`0xF1`/`0xF2`/`0xF3`), 14-byte `0xE0`/`0xE1` gamma pairs, and the long
+`0x60`–`0xD9` timing block, in Espressif's ST77916 order across a 175-entry unbroken run.
+It shares **no** opcode with the SH8601 component's own default. That corroborates
+Waveshare's ST77916 declaration and confirms that `esp_lcd_sh8601` is functioning here as a
+QSPI command/DCS transport whose vendor-array hook the project fills with an ST77916
+sequence.
+
+**Not supported, and not claimed.** None of this reads the silicon. Sequence shape is
+evidence about the command set a panel accepts, not proof of a die marking. Payload values
+differ from Espressif's ST77916 default at 95 of 179 matched opcodes, which is ordinary
+per-panel tuning but is also exactly the sort of difference that a related-but-distinct
+controller would produce. The physical controller marking stays in
+[Still requires physical inspection](#still-requires-physical-inspection). This record does
+not describe `esp_lcd_sh8601` as the physical controller, and does not describe it as "merely
+a transport shim" either — it performs real DCS setup, as item 2 above shows.
+
+---
+
+## Release-artifact-observed facts
+
+Immutable v2.5.1 assets, published 2026-03-23T00:04:50Z:
+
+| Asset | URL | Bytes | SHA-256 |
+|---|---|---|---|
+| `roon_knob.bin` | <https://github.com/muness/roon-knob/releases/download/v2.5.1/roon_knob.bin> | 1 753 184 | `1fd8de2bc1c105a7259775dfc52ab4ed8fd9bf57bb251f73d55f91aa9bc0f2c7` |
+| `roon_knob_merged.bin` | <https://github.com/muness/roon-knob/releases/download/v2.5.1/roon_knob_merged.bin> | 1 818 720 | `3218db765e56ea0469e330a8a2d496ed0fbf9e17ac168d3b9ba01731b413251b` |
+
+### Image headers — the flash-size disagreement
+
+Byte 3 of an ESP image header packs SPI flash frequency in the low nibble and **flash size
+in the high nibble** (`0x3` = 8 MB, `0x4` = 16 MB).
+
+| Artifact | First four bytes | Segments | Flash-size nibble | Declared size |
+|---|---|---|---|---|
+| `roon_knob_merged.bin` (bootloader header at offset 0) | `e9 04 02 3f` | 4 | **`0x3`** | **8 MB** |
+| `roon_knob.bin` (application header at offset 0) | `e9 07 02 4f` | 7 | **`0x4`** | **16 MB** |
+
+Both carry `chip_id = 0x0009` (ESP32-S3) at offset 12 and SPI mode `0x02` (DIO).
+
+The 8 MB value comes from `esptool ... merge-bin --flash-size 8MB` in the release workflow;
+the 16 MB value comes from `CONFIG_ESPTOOLPY_FLASHSIZE="16MB"` in `idf_app/sdkconfig.defaults`.
+
+**This record makes no geometry decision and recommends none.** It supplies the measurement
+only. Which value is correct, and what to change, is
+[#203](https://github.com/muness/roon-knob/issues/203)'s acceptance criterion, and #203's
+16 MB direction in turn depends on physical flash verification.
+
+### Application descriptor of `roon_knob.bin`
+
+`esp_app_desc_t` begins at file offset 32, magic `0xABCD5432`.
+
+| Field | Value |
+|---|---|
+| `magic_word` | `0xABCD5432` |
+| `secure_version` | `0` |
+| `version` | `2.5.1` |
+| `project_name` | `roon_knob` |
+| `time` | `00:02:47` |
+| `date` | `Mar 23 2026` |
+| `idf_ver` | `v5.4.3-1245-gbdc4dc5e9e` |
+| `app_elf_sha256` | `882819856bd8e224d15209f945b8b0180bd1656976bb768d40aa4d5558c252e9` |
+| `min_efuse_blk_rev_full` | `0` (encoded `major*100 + minor`, so v0.0) |
+| `max_efuse_blk_rev_full` | `199` (v1.99 — the IDF default upper bound, not a measured device revision) |
+| `mmu_page_size` | `16` — stored as log2, so 64 KiB |
+
+### Reproduce
+
+Prerequisites: network access, `bash`, and the host tools `curl`, `shasum`, `wc` and `xxd`.
+
+```bash
+mkdir -p /tmp/rk-v251 && cd /tmp/rk-v251
+for f in roon_knob.bin roon_knob_merged.bin; do
+  curl -sSL -o "$f" "https://github.com/muness/roon-knob/releases/download/v2.5.1/$f"
+done
+shasum -a 256 roon_knob.bin roon_knob_merged.bin
+wc -c roon_knob.bin roon_knob_merged.bin
+
+# flash-size nibble = high nibble of byte 3
+for f in roon_knob_merged.bin roon_knob.bin; do
+  printf '%s byte3=0x%s\n' "$f" "$(xxd -p -s 3 -l 1 "$f")"
+done
+
+xxd -l 24 roon_knob_merged.bin      # magic, segments, spi mode, byte3, entry, chip_id
+xxd -l 24 roon_knob.bin
+xxd -s 32 -l 224 roon_knob.bin      # application descriptor
+```
+
+A maintained tool reports the same fields. The spelling depends on which esptool generation is
+installed, and the two forms must not be combined — the hyphenated command does not take
+`--version`, and the underscored one is not the current name:
+
+```bash
+# esptool v5 (current): hyphenated command, no --version option
+esptool image-info roon_knob.bin
+
+# esptool v4 (legacy): underscored command, v2 layout must be requested explicitly
+esptool.py image_info --version 2 roon_knob.bin
+```
+
+See Espressif's [esptool migration guide](https://docs.espressif.com/projects/esptool/en/latest/esp32/migration-guide.html)
+for the full renaming. The `xxd` form above is given because it does not depend on which
+esptool generation is present, not because it needs nothing installed.
+
+---
+
+## Historical claims, now superseded
+
+These statements were published in this repository and are **incorrect for this board**.
+They are recorded so the mistake is traceable and so the regression checker has a named
+target list.
+
+| Superseded claim | Where it appeared | Corrected value |
+|---|---|---|
+| Product is "Waveshare ESP32-S3 Touch AMOLED 1.8″" | this file's former title, `HARDWARE_PINS.md`, `COLORTEST_HELLOWORLD.md` | ESP32-S3-Knob-Touch-LCD-1.8 |
+| Panel is a round AMOLED | this file, `HARDWARE_PINS.md`, `DISPLAY.md`, `DUAL_CHIP_ARCHITECTURE.md`, `docs/README.md` | IPS LCD |
+| 16.7 M colours | this file | 262 K colours |
+| "No PWM backlight control needed (AMOLED is self-emitting)" / "Backlight (always on ...)" | this file, `HARDWARE_PINS.md` | PWM backlight on GPIO 47; initial duty is `CONFIG_RK_BACKLIGHT_NORMAL`, Kconfig default 100 of 255 (≈ 39 %) |
+| Backlight "started at 50 % duty" | this file's first draft, `HARDWARE_PINS.md`, `DISPLAY.md` | ≈ 39 % (100 of 255). The 50 % duty figure came from a stale comment at `platform_display_idf.c:456`, not from any value the code sets |
+| SH8601 is the display controller | this file, `DISPLAY.md`, `HARDWARE_PINS.md`, `IMPLEMENTATION_NOTES.md`, `docs/README.md` | Vendor declares ST77916; `esp_lcd_sh8601` is the software component |
+| Primary module is "ESP32-S3-WROOM-1 (R8)" | this file, `DUAL_CHIP_ARCHITECTURE.md` | Vendor declares the SoC as ESP32-S3R8; the module package is unverified |
+| Secondary chip is "ESP32-WROOM" | `DUAL_CHIP_ARCHITECTURE.md` | Vendor declares ESP32-U4WDH with 4 MB flash |
+| "Rotary encoder with push button" | `DEVELOPMENT.md` | No button is read by this firmware; shaft switch presence unconfirmed |
+| "Press the knob → open zone picker" | `README.md` | The zone picker opens on a touch click of the zone name |
+| "Tap the screen → play/pause" | `README.md` | Play/pause is the centre button of the transport row (`common/ui.c:477` – `:496`); a tap elsewhere does not toggle playback, and a double-tap enters art mode (`idf_app/main/platform_display_idf.c:422` – `:436`) |
+| Touch part asserted as a specific variant ("CST816D", "CST816S") | `IMPLEMENTATION_NOTES.md`, `TOUCH_INPUT.md`, `cst816d.md` | Vendor declares the CST816 family; the fitted marking is unverified |
+
+The superseded wordings quoted in this section — the panel technology, the colour-depth figure,
+the component-as-controller claim, the module package, the knob press — are quotations, not
+assertions. `scripts/check_docs_identity.py` exempts **this section only**, by heading, and
+requires the section to keep restating something guarded: an allowance that stops suppressing
+anything is reported as a structure failure rather than left as a silent hole.
+
+---
+
+## Still requires physical inspection
+
+None of the following is treated as verified anywhere in this repository, and no document
+may state them as fact without new evidence.
+
+| Open question | Why it needs the device | Blocks |
+|---|---|---|
+| Exact flash chip part, die revision, and true capacity | Vendor "16MB Flash" is a marketing figure; only `esptool flash-id` / `flash_id` on the owned unit reads the actual part | #203's 16 MB direction |
+| Physical panel controller marking | Sequence shape and vendor declaration corroborate ST77916 but cannot read a die | Porting advice precision; nothing releasable |
+| Exact touch controller marking (CST816 vs CST816D vs CST816S vs CST816T) | Vendor declares the family; the linked datasheet is CST816D; earlier docs in this repository asserted CST816S; the project reads raw registers that several variants share | Nothing currently |
+| ESP32-S3 module package and revision | Vendor names the SoC, not the module | #203, #193 profiles |
+| Whether the encoder shaft has a push switch, wired or not | The firmware reads no button, which proves the firmware's behaviour, not the mechanism | Any future press gesture |
+| Whether the second encoder is populated and reachable from the ESP32-S3 | Vendor says it acts on the secondary SoC; this firmware never reads it | #199 shared input work |
+| PSRAM mode and timing as fitted | Vendor declares 8 MB octal-capable; effective config is a separate question | #203 |
+| Board revision silkscreen of the owned unit | Cannot be inferred from any source used here | #193 inventory |
+
+`#189` owns the release-blocking hardware checklist; this record does not discharge any of it.
+
+---
+
+## Related documents
+
+Each of these owns its own subject matter and defers identity to this file.
+
+- [HARDWARE_PINS.md](HARDWARE_PINS.md) — GPIO assignments as the firmware sets them
+- [COLORTEST_HELLOWORLD.md](COLORTEST_HELLOWORLD.md) — RGB565 byte order and LVGL colour format
+- [cst816d.md](cst816d.md) — touch controller integration notes
+- [encoder.md](encoder.md) — quadrature decoding notes
+- [battery.md](battery.md) — battery monitoring circuit
+- [drv2605.md](drv2605.md) — haptic driver
+- [../DISPLAY.md](../DISPLAY.md) — display subsystem and LVGL integration
+- [../DUAL_CHIP_ARCHITECTURE.md](../DUAL_CHIP_ARCHITECTURE.md) — the two-SoC hardware and its unused secondary
+- [../../howto/PORTING.md](../../howto/PORTING.md) — porting guidance
+- [../../meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md](../../meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md) — why this record exists and how it is enforced

--- a/docs/esp/hw-reference/cst816d.md
+++ b/docs/esp/hw-reference/cst816d.md
@@ -1,8 +1,15 @@
-Self-Capacitive Touch Controller CST816D – App-Facing Notes
+Self-Capacitive Touch Controller CST816-family – App-Facing Notes
 
 Purpose
-- Summarize only what matters to integrate a CST816D-based touch panel with our ESP32/LVGL firmware.
+- Summarize only what matters to integrate a CST816-family touch panel with our ESP32/LVGL firmware.
 - Focus on wiring, init, event flow, and pitfalls that affect reliability.
+
+Which part is actually fitted
+- Waveshare declares the touch IC as **CST816** and links a **CST816D** datasheet; the exact
+  marking on the owned device is unverified, and this firmware reads raw registers that
+  several variants share. The canonical record is [board.md](board.md) — do not treat the
+  variant letter in this file's *filename* as a verified fact — the title above deliberately
+  says CST816-family.
 
 What It Is
 - Single‑touch, self‑capacitive touch controller with gesture detection.

--- a/docs/esp/hw-reference/encoder.md
+++ b/docs/esp/hw-reference/encoder.md
@@ -1,9 +1,15 @@
 Rotary Encoder (EC11‑class) – App‑Facing Notes
 
+This file owns quadrature decoding technique and tuning. Board identity — how many encoders
+the vendor declares, and what is still physically unverified — is in the canonical record:
+[board.md](board.md).
+
 Overview
 - Mechanically‑detented quadrature rotary encoder used for volume and navigation.
 - Two digital outputs: Channel A (ECA) and Channel B (ECB).
-- Our board’s shaft is rotation‑only (no push switch wired).
+- This firmware reads rotation only; it reads no shaft switch on any GPIO. Whether a switch is
+  fitted on the owned unit is unconfirmed — see
+  [board.md](board.md#still-requires-physical-inspection).
 
 Electrical
 - Open‑collector style contacts; require pull‑ups. Firmware enables internal pull‑ups.
@@ -35,5 +41,6 @@ Testing
 
 References
 - Implementation: idf_app/main/platform_input_idf.c (ENCODER_GPIO_A/B, debounce, polling).
-- Pinout: docs/references/HARDWARE_PINS.md.
+- Pinout: [HARDWARE_PINS.md](HARDWARE_PINS.md).
+- Board identity: [board.md](board.md).
 

--- a/docs/esp/hw-reference/image_render.md
+++ b/docs/esp/hw-reference/image_render.md
@@ -17,7 +17,7 @@ Transport Recommendations (HTTP)
 
 Sidecar (Server) Knobs
 - Proxy via RoonApiImage with `width/height/scale` to bound bytes. Use `format=jpeg` (if available) and re‑encode if the core cannot.
-- Optional: provide `format=rgb565` that returns a raw RGB565 frame (**big‑endian/byte-swapped** to match SH8601 QSPI display) with `Content-Type: application/octet-stream` for zero‑decode on the device. Include `X-Width`, `X-Height` headers.
+- Optional: provide `format=rgb565` that returns a raw RGB565 frame (**big‑endian/byte-swapped** to match the QSPI panel) with `Content-Type: application/octet-stream` for zero‑decode on the device. Include `X-Width`, `X-Height` headers.
 - Return placeholder SVG/PNG only when artwork is absent.
 
 Decoder choices (ESP32‑S3)
@@ -26,7 +26,7 @@ Decoder choices (ESP32‑S3)
   - Feed from the HTTP buffer via read callbacks; write RGB565 scanlines into an LVGL image/canvas.
 - ESP‑IDF esp_jpeg (IDF 5.x) **[Currently Used]**
   - Native component with examples; decode to RGB565 buffer (PSRAM‑backed) and blit.
-  - **Important**: Use `JPEG_PIXEL_FORMAT_RGB565_BE` (big-endian) output to match the SH8601 QSPI display's byte order. See `common/ui_jpeg.c`.
+  - **Important**: Use `JPEG_PIXEL_FORMAT_RGB565_BE` (big-endian) output to match the QSPI panel's byte order. See `common/ui_jpeg.c`.
 - Others (Bitbank JPEGDEC / TJpg_Decoder)
   - Viable; prefer TJpgDec/esp_jpeg for clean LVGL/IDF integration.
 
@@ -71,5 +71,5 @@ Example Sequence
 References
 - RoonApiImage: `get_image(image_key, {scale,width,height,format}, cb)` (proxied by sidecar)
 - LVGL image decoder docs; ESP‑IDF `esp_jpeg` example
-- **Color Configuration**: See `docs/references/COLORTEST_HELLOWORLD.md` for SH8601 display byte order and LVGL 9 color format setup
+- **Color Configuration**: See [COLORTEST_HELLOWORLD.md](COLORTEST_HELLOWORLD.md) for panel byte order and LVGL 9 color format setup
 

--- a/docs/esp/hw-reference/touch.md
+++ b/docs/esp/hw-reference/touch.md
@@ -1,7 +1,10 @@
 Touch UI Handling – Patterns and Hooks
 
+This file owns the LVGL touch event wiring. Board identity, including the exact touch part and
+what remains unverified, is in the canonical record: [board.md](board.md).
+
 Input Path
-- Hardware: CST816 capacitive touch over I2C.
+- Hardware: capacitive touch over I2C at address `0x15`.
 - LVGL: Registered as a `LV_INDEV_TYPE_POINTER` in `platform_display_idf.c`.
   - Callback: `lvgl_touch_read_cb()` fills `lv_indev_data_t` with `(x,y)` and `PRESSED/RELEASED`.
 

--- a/docs/howto/PORTING.md
+++ b/docs/howto/PORTING.md
@@ -52,7 +52,7 @@ If you want to build a different application for the Waveshare ESP32-S3 Knob (e.
 
 | Component | Files | Notes |
 |-----------|-------|-------|
-| Display init | `platform_display_idf.c` | SH8601 QSPI setup, LVGL driver |
+| Display init | `platform_display_idf.c` | QSPI panel setup, LVGL driver |
 | Touch input | `lcd_touch_bsp.c`, touch code in display | CST816 I2C |
 | Rotary encoder | `platform_input_idf.c` | Quadrature decoding |
 | Battery monitoring | `battery.c` | ADC, voltage curve |
@@ -154,10 +154,14 @@ To port Roon Knob to a different ESP32-S3 display board:
 // ... etc
 ```
 
-**Display controller**: If not using SH8601:
+**Display controller**: The Roon Knob target's panel driver IC and the software component it
+is driven through are two different things — read
+[board.md](../esp/hw-reference/board.md#panel-controller-versus-software-driver) before
+assuming either. For a different panel:
 1. Find or write an ESP-IDF component for your display IC
 2. Replace `esp_lcd_new_panel_sh8601()` with your driver
-3. Adjust initialization commands
+3. Supply your panel's initialization array (and check whether your component sends DCS
+   `MADCTL`/`COLMOD` itself before that array, as this one does)
 
 **Resolution**: Search for `360` and update:
 - `LCD_H_RES`, `LCD_V_RES`
@@ -223,13 +227,13 @@ Hypothetical changes for a common alternative board:
 
 | Component | Waveshare Knob | T-Display-S3 |
 |-----------|----------------|--------------|
-| Display | SH8601 360×360 QSPI | ST7789 170×320 SPI |
-| Touch | CST816 I2C | None (buttons only) |
+| Display | 360×360 QSPI (see [board.md](../esp/hw-reference/board.md)) | ST7789 170×320 SPI |
+| Touch | Capacitive, I2C `0x15` | None (buttons only) |
 | Encoder | GPIO 7/8 | None |
 | Input | Encoder + touch | Two buttons |
 
 **Changes needed:**
-1. Replace SH8601 driver with ST7789
+1. Replace the `esp_lcd_sh8601`-based panel driver with ST7789
 2. Change from QSPI to standard SPI
 3. Update resolution to 170×320
 4. Remove touch code, add button input

--- a/docs/meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md
+++ b/docs/meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md
@@ -1,0 +1,652 @@
+# Decision: one provenance-classed target identity record, enforced by a host check
+
+**Date:** 2026-07-30
+**Status:** Accepted
+**Issue:** [#211](https://github.com/muness/roon-knob/issues/211) · Parent
+[#193](https://github.com/muness/roon-knob/issues/193) · Program
+[#201](https://github.com/muness/roon-knob/issues/201) · Feeds
+[#203](https://github.com/muness/roon-knob/issues/203),
+[#117](https://github.com/muness/roon-knob/issues/117),
+[#190](https://github.com/muness/roon-knob/issues/190)
+
+## Context
+
+The repository described its only shipping target inconsistently. `README.md` named the
+Waveshare **ESP32-S3-Knob-Touch-LCD-1.8**; `docs/esp/hw-reference/board.md` named an
+"ESP32-S3 Touch AMOLED 1.8″", claimed 16.7 M colours, and stated that no backlight control
+was needed — while the firmware configures an LEDC PWM backlight on GPIO 47. Several
+documents called `SH8601` the display controller, which is the name of a *software
+component*, not of the driver IC the vendor declares. `DEVELOPMENT.md` advertised an encoder
+push button that no code reads, and `README.md` advertised a knob press that no code
+implements.
+
+The first cut of this correction reproduced the same failure in miniature: it stated that the
+firmware drives the backlight at 50 % duty, which is what a stale comment at
+`platform_display_idf.c:456` says, not what the code does — the channel configuration at `:471`
+reads `CONFIG_RK_BACKLIGHT_NORMAL`, whose Kconfig default is 100 of 255, about 39 %, and which
+`docs/dev/KCONFIG.md` had documented correctly all along. That is the origin of decision 8
+below: source comments are not evidence.
+
+The previous position was to correct nothing until the physical device had been inventoried.
+That kept a demonstrably wrong record published, and it conflated two different problems:
+facts already settled by primary vendor sources, this repository's own code, and immutable
+release binaries; versus facts that genuinely need the device in hand.
+
+## Decision
+
+1. **`docs/esp/hw-reference/board.md` is the single canonical identity record.** No second
+   `TARGET_IDENTITY.md` is created. A competing file would have reproduced the original
+   failure in a new location. This single-record invariant is enforced by human review, not
+   by `check_docs_identity.py`: the checker catches known contradictory wording, while
+   `REQUIRE_CANONICAL_LINK` is a hand-maintained list and does not discover a new, truthful
+   identity-bearing document automatically.
+
+2. **Every fact in it carries a provenance class** — vendor-declared, repository-observed,
+   release-artifact-observed, historical/superseded, or physically unverified. Unverified
+   facts are listed explicitly with what blocks them, and none is treated as verified
+   anywhere.
+
+3. **Other documents keep only the facts they own and link to the canonical record.** Pin
+   tables, driver mechanics, colour-format notes, and porting steps stay where they are;
+   independent restatements of product identity do not.
+
+4. **Driver wording is fixed to what the source supports.** The project *replaces* the
+   `esp_lcd_sh8601` component's vendor-specific init array; the component still sends
+   standard DCS `MADCTL`/`COLMOD` setup *before* that array; the project's array overwrites
+   `MADCTL` (its last entry is `{0x36, {0x00}}`) while `COLMOD` remains governed by
+   `panel_dev_config.bits_per_pixel`. The project's 185-entry array is byte-for-byte
+   Waveshare's own sequence for this product and is structurally an ST77916-family sequence
+   (0.8928 opcode-sequence similarity to Espressif's `esp_lcd_st77916` SPI default, longest
+   equal run 175) with **zero** opcode overlap with the SH8601 component's own default. That
+   corroborates the vendor's ST77916 declaration; it is explicitly **not** a claim about
+   physical silicon.
+
+5. **Artifact evidence is recorded, not acted on.** The v2.5.1 flash-size disagreement
+   (merged header nibble `0x3` = 8 MB, application header nibble `0x4` = 16 MB), the exact
+   SHA-256s, and the application descriptor are recorded with reproducible commands. **No
+   geometry decision is made here** — that is #203's, and #203's 16 MB direction still
+   depends on physical flash verification.
+
+6. **A host-only checker is a tripwire for the corrections, repo-wide, with scoped
+   exemptions.** `scripts/check_docs_identity.py` (standard library only, no network) scans
+   Markdown across the repository for the known product-name, panel-type, colour-depth,
+   backlight-absence, backlight-duty, controller, module-package, encoder-button and
+   touch-variant contradictions, and verifies that the canonical record keeps its provenance
+   structure and that identity-bearing documents still link to it. It runs in its own
+   workflow, `.github/workflows/docs-identity.yml`.
+
+   **What it is.** Nine regular expressions over normalised prose. For the single-physical-line
+   renderings in the fixtures, its demonstrated recall is exactly two sets: the wordings that
+   were actually in this repository before #211, each pinned by a rule probe and a fixture; and
+   the paraphrases in
+   `scripts/fixtures/docs_identity/paraphrases.tsv`, authored outside the checker so that "the
+   regex matches its own example" cannot be mistaken for coverage. That corpus exists because a
+   dissent pass wrote fifteen ordinary-prose restatements of these same contradictions and the
+   first rule table caught only three. Quoting the shapes it missed, as strings rather than as
+   claims — the guard reads prose, so these are fenced deliberately:
+
+   ```text
+   spelled-out AMOLED ("active-matrix organic LED")
+   the colour count as digits (16777216) and as a bit depth ("24-bit colour")
+   self-illumination as a reason there is nothing to dim
+   the encoder press as "click the dial" / "push the dial in" / "shaft switch selects"
+   SH8601 as silicon, or attributed to Sitronix
+   the module package with separators dropped (ESP32S3 WROOM 1)
+   the duty figure written in words (fifty percent)
+   the touch variant as a bare part number (CST816S)
+   ```
+
+   The rules were widened until all fifteen are reported, and each sentence is now an individual
+   test. The corpus is therefore independently authored but **fitted**, not held out: the wrap
+   figures below measure sensitivity on fitted data, not general recall on unseen wording. Issue
+   #213 requires held-out wording before #205 may make the check required.
+
+   **Nine is a rule count, not a coverage number.** Each rule is an alternation of several
+   clauses, and the per-rule fixture proves that *one* clause fires. Nothing here claims that the
+   number of rules equals the number of covered alternation branches, and neither the checker nor
+   the fixture suite asserts such an equality. A clause is pinned only where a paraphrase in the
+   corpus happens to exercise it; adding a clause adds reach but no evidence of reach.
+
+   **What it is not.** It is not a semantic or factual check, and a relapse is **not**
+   guaranteed to become a CI failure. Only a relapse in a known or tested wording is. Prose that
+   never names a guarded token ("the screen makes its own light"), a colour depth given only as a
+   hex range, a claim carried in an image, a diagram, a translated spec table or a fenced code
+   example, and any file this scan does not read, all pass. Matching is per physical line, so a
+   guarded phrase broken across lines can also pass; `CONTROLLER_CLAIM`, `BACKLIGHT_DUTY` and
+   `ENCODER_BUTTON` have no single-token clause that survives every such break. The fixture suite
+   pins all three blind spots as current behaviour so #213 must flip explicit expectations when it
+   closes the gap. Human review of identity claims remains required. The
+   check's job is to make the cheap relapses loud and to make any widening of the exemptions a
+   reviewed change to a Python file rather than a documentation edit.
+
+   A reproducible audit estimate applies Python `textwrap.wrap` to each of the 15 paraphrases at
+   every starting column, using initial indentation to represent that column, then tests its
+   designated rule against each physical output line. At 88 columns, 120 of 1,320 offsets (9.1 %)
+   are missed: `BACKLIGHT_DUTY` 20/88, `CONTROLLER_CLAIM` 49/264, `ENCODER_BUTTON` 40/264,
+   `COLOR_DEPTH` 7/176, `PANEL_AMOLED` 4/88, and zero for the other rules. At 100 columns the same
+   120 misses are 8.0 % of 1,500 offsets. This is fitted-data sensitivity, not a recall guarantee;
+   #213 owns the formal audit and any mechanism change.
+
+   **Scan scope, stated as mechanisms rather than counts, because counts drift.** Every
+   non-exempt file ending in `.md` at any depth is scanned, including `.github/**/*.md` — `.github/RELEASE_TEMPLATE.md`
+   ships release prose that describes the target, so it is documentation for this purpose. There
+   are two content-specific exclusions: contradiction fixtures under `scripts/fixtures/`, which
+   must contain guarded wording, and the bot-managed root `CHANGELOG.md` described below. There
+   is no dot-directory rule: a directory is skipped only when its exact name appears in
+   `SKIP_DIRS` (version control, interpreter and tool caches, build output, vendored
+   dependencies), so a future `.notes/` is scanned rather than silently exempt. An earlier cut
+   excluded every dot-directory while claiming a repo-wide scan; `--self-check` now fails if
+   `.github` is put back into `SKIP_DIRS`, and the fixture suite pins both the `.github` scan and
+   the exact list of excluded directory names.
+
+   **Within a file, two constructs are not prose, and neither may hide the rest of the
+   document.** Fenced code is exempt — quoting a superseded wording as source is legitimate — and
+   HTML comment bodies are stripped before scanning. Both are things that *end*, and the first cut
+   of the checker did not check that they did. Fences were a boolean toggled by any
+   `^\s{0,3}(```|~~~)` line, so tildes could "close" a backtick fence and a three-character run
+   could "close" a four-character one; a comment opener with no closing marker swallowed every
+   following line. In both cases the tail of the file was silently unscanned and the run could
+   still be green. Fences are now matched CommonMark-shaped — a closer must use the same
+   character, be at least as long as the opener, and carry nothing after it — and an opener left
+   unclosed at end of file, of either kind, is a `STRUCTURE` failure naming the file and the
+   opening line. Structure outranks violation in the exit precedence for exactly this reason: a
+   document that hid its own tail is the state in which a contradiction cannot be seen, so it must
+   not be reportable as clean. Valid Markdown is unaffected: info strings, longer closers, tilde
+   fences containing backtick fences, indented fences and inline `` `code` `` spans on their own
+   line all keep working, and `fence_valid.md` plus `comment_closed.md` pin that they do.
+
+   **Indented code is not one of those two constructs: it is scanned as prose, and the reporting says
+   so.** A four-space indented block is code to CommonMark and is deliberately not exempt here.
+   Recognising it would mean tracking list and blockquote context to tell a code block from a
+   continuation line, and an indentation-only exemption would exempt the reflowed middle of a
+   paragraph — including every indented rendering the wrap audit above uses to represent a starting
+   column, and those renderings are the corpus this guard's only recall evidence rests on. So the gap
+   is kept. What was
+   missing was discoverability: an author who indented a quotation of a superseded wording got a
+   violation on a line they had marked as code, with nothing in the output explaining why. Every
+   violation report now carries the remedy — quote source in a fenced block, because an indented
+   block is scanned as prose — printed once with the violation lines, carried in the JSON report as
+   `quoting_note`, and rendered beneath the violations in the CI step summary.
+   `indented_code_scanned.md` pins both halves: the indented block is reported, and the same lines
+   inside a fence are not, so the remedy is one that works.
+
+   **Rule-level suppressions are observable.** Some rules carry an `unless` clause so that
+   truthful qualified prose passes: a note that RGB888 is a 24-bit pixel format is not a claim
+   about the panel, and a reference to the datasheet the vendor links is not a claim about the
+   fitted part. That escape used to be invisible — it lived only in the regex, so widening one
+   shrank the guard with no trace in a report. Every hit a suppressor excuses is now recorded with
+   file, line, rule id, matched text and the suppressor text that excused it, and surfaced in the
+   JSON report (`suppressions`), in the summary counters (`suppressed=`), in one informational
+   `RK-IDENT-SUPPRESSED` line per hit, and under its own heading in the CI step summary. The exit
+   code is deliberately unchanged: a run whose only findings are suppressions is still
+   `RK-IDENT-OK` and still exit 0, because making qualified prose fail is the failure mode this
+   escape exists to prevent. Visibility is the whole mechanism — a widened suppressor shows up as
+   a longer suppression list in review. `--self-check` replays each rule's `probe_exempt` through
+   the scanner and fails if the suppressed hit is not recorded, so removing the observability is
+   an exit-4 self-check failure rather than a quiet narrowing.
+
+   **The suppression set is pinned as a fingerprint, not as a scalar total.** Visibility only works if
+   someone looks, and a longer list in a step summary is easy to scroll past. The fixture suite
+   therefore pins the repository's suppression *set* as an exact fingerprint — one
+   `rule|file|suppressor|count` line per distinct triple — and fails in either direction.
+
+   The shape of that fingerprint is the decision. A scalar total was rejected on review: it is
+   blind to the change most worth seeing, one suppressor being swapped for another at an unchanged
+   total, which is exactly what a widening looks like once someone also removes a suppressed line.
+   Line numbers and matched prose are excluded for the opposite reason: they churn on every edit
+   above a suppressed line and on every rewording, and a baseline that fails for reasons nobody
+   cares about gets updated by reflex instead of read.
+
+   The per-triple **count** is the third term, and it closes a hole the first two left open. A
+   fingerprint of distinct triples alone treats an already-listed line as a standing licence: once
+   `TOUCH_VARIANT|docs/esp/hw-reference/cst816d.md|datasheet` is in the baseline, a second, third and
+   fourth sentence in that file may take the same excuse from the same rule and nothing moves. That
+   is a widening in the only currency that matters — how much prose the guard has stopped reading —
+   and it was invisible. With the count, every additional suppressed hit fails and the diff says how
+   many. The count is not a reintroduction of the excluded terms: it says how many hits a triple
+   excuses, never which lines or which words.
+
+   So the fingerprint watches which suppressor excuses which rule in which file, and how often, and
+   nothing else. The suite proves all three properties — a one-for-one substitution fails at an
+   unchanged total, an additional hit inside an already-pinned triple fails on the count, and
+   shifting every line number while replacing every matched string changes nothing.
+
+   Those three proofs run against a **fixed synthetic** suppression set rather than the live one,
+   which is itself a correction made on review. Derived from the live baseline, the control asserting
+   "line numbers and prose are ignored" compares the live fingerprint against the pinned constant —
+   so the moment the repository legitimately gains or loses a suppression, one honest documentation
+   edit reports two failures: "the baseline moved", which is true and is the intended friction, and
+   "the fingerprint no longer ignores line numbers", which is false and points a reader at the wrong
+   mechanism. A false diagnostic attached to the expected failure is how a baseline gets updated
+   without being read. Synthetic rows keep one cause to one failure.
+
+   That failure is deliberately **review friction, not a runtime failure of truthful prose**: the
+   checker itself still exits 0 on a run whose only findings are suppressions, and no suppressed
+   line is being called untruthful. It means "a suppressor is now excusing a different set of
+   lines; say in review which, or narrow it". The failure message prints a diff of pinned against
+   actual, names the command to run, and says what to establish in review before the constant is
+   updated.
+
+   **Source anchors keep the repository-observed citations fresh.** The `R` rows are claims about
+   this repository's *source*, each citing a file — and a prose rule cannot notice when the cited
+   source moves out from under the prose, which leaves documentation that is word-for-word
+   correct-looking and no longer connected to anything. `SOURCE_ANCHORS` pins the stable,
+   load-bearing, positively quotable ones as explicit (file, expected tokens) assertions: the QSPI
+   pin mapping with the bus, panel-IO and reset sites that consume it; the GPIO 47 backlight pin
+   with its LEDC channel, 8-bit resolution and 5 kHz timer; the `CONFIG_RK_BACKLIGHT_NORMAL` duty
+   assignment and the Kconfig stanza behind it; the init array's declaration, its `{0x36, {0x00},
+   1, 0}` terminator and the `vendor_config` binding that carries it; the
+   `esp_lcd_new_panel_sh8601` call and the `bits_per_pixel` of the config it is handed; the encoder
+   A/B pin definitions with the `gpio_config` and `gpio_get_level` sites that use them; the `0x15`
+   touch address and the 7-byte register read; the unpinned `esp_lcd_sh8601` dependency; and the
+   zone picker's click registration, emitter, handler and default label literal. A cited file that
+   is absent, or one that no longer carries an expected token, is a named non-zero `STRUCTURE`
+   finding, and the full inventory with each anchor's status is in the JSON report's
+   `source_anchors` so a reader sees what was checked rather than only what failed.
+
+   **A token must state the relationship it is cited for.** The first cut split facts into
+   fragments — `PIN_NUM_BK_LIGHT` and `((gpio_num_t)47)` as separate tokens — and that is a false
+   positive waiting to happen: both survive a file in which the name and the number have drifted
+   apart, so the guard would report a fresh citation for a relationship that no longer exists.
+   Every token is now a whole line or a whole block that carries the relationship itself. To make
+   that safe, matching is whitespace-insensitive (so realignment and reflow do not break a pinned
+   line, and a multi-line stanza can be one token) and word-boundary guarded (so `0x15` does not
+   match `0x152`). `--self-check` refuses a token that is a bare identifier or bare literal, which
+   is the shape the fragments had, so the table cannot slide back. The fixture suite pins all of
+   it: a repointed encoder pin that leaves the old value in a trailing comment must fail, a widened
+   `0x155` must fail, and a realigned line must not.
+
+   **What an anchor is worth, stated precisely.** A present token proves the *citation* is still
+   fresh. It is **not** evidence that the board behaves that way, that the value is right, or that
+   the surrounding claim is true — the provenance classes exist because source text and silicon are
+   different kinds of evidence, and a token check cannot collapse that distinction. In the other
+   direction a missing token proves the citation is **stale**, not that the claim is false; the
+   remedy is to re-read the source and re-derive the row, and the finding says so in those words.
+
+   **An anchor does not check the line numbers a row cites.** The `R` rows cite lines —
+   `platform_display_idf.c:55` – `:61` — and an anchor checks text. Insert forty lines above an
+   anchored block and every token is still present, every anchor still reports fresh, and every
+   `:NN` in the Markdown is now wrong. Line-citation drift is therefore **invisible to this layer
+   by construction**, and that is a choice rather than an oversight: asserting line numbers would
+   turn every unrelated edit above a cited line into a red documentation guard, which is how a
+   check earns deletion. Keeping the cited lines correct stays human review, and is #213's. The
+   checker's docstring, the finding wording, the JSON report, the step summary, the workflow
+   commentary and the fixture notes all say so, because a green run invites exactly the opposite
+   assumption.
+
+   **The anchor count is not coverage.** `anchors_fresh=N/N` means every anchor in the table is
+   fresh; it does **not** mean every `R` row is anchored, and no equality between the two is
+   asserted anywhere — the fixture suite pins a floor and specific anchor ids, never a match
+   against the number of rows. Rows stay unanchored for two reasons. **Negative and uniqueness
+   claims** cannot be anchored at all: "no physical button is read anywhere in the firmware",
+   "no `128` literal exists in the file and no code path implements the stale 50 % claim", and
+   "`zone_label_event_cb` is the *only* emitter of
+   `UI_INPUT_MENU`" are assertions about absence, and a token's presence would say nothing about
+   everywhere else while its absence would say nothing at all. **Derived and external facts** are
+   not quotable repository text: the 185-entry and 146-distinct-opcode counts come from reading the
+   array, the demo-archive diff and the `difflib` similarity figures come from files outside this
+   repository, and no row about the silicon is anchorable in principle. Those rows stay derived by
+   human reading, and the anchors covering their neighbours must not be mistaken for covering them.
+
+   **The guard is reachable locally as a direct command.** `python3
+   scripts/check_docs_identity.py --self-check` is host-only — standard library, no ESP-IDF, no
+   network, no writes — and is named in both `AGENTS.md` and `docs/dev/DEVELOPMENT.md`, which is
+   where a contributor or an agent looks before editing documentation. A guard whose only home is a
+   workflow is one contributors meet for the first time in a red pull request.
+
+   It is deliberately not wired into `scripts/ci_sanity.sh`. An earlier cut put it at the top of
+   that script and described it as the local gate; that description did not survive review.
+   `ci_sanity.sh` runs `cmake` and then `idf.py build`, so it cannot run on a host without a
+   toolchain — which is precisely the host this check is for — and no workflow in this repository
+   invokes it, so calling it "the local gate" overstated what it is. The fixture suite runs the
+   direct command instead, and pins the phrase both documents use, so the state of that script and
+   the state of the documentation cannot disagree in either direction without a failure.
+
+   The canonical record exercises this mechanism rather than relying on a synthetic example:
+   its repository-observed row quotes the **stale comment's** 50 % duty claim before deriving the
+   real value from Kconfig. `BACKLIGHT_DUTY` therefore exempts explicit stale/historical/comment
+   attribution while still rejecting the same duty claim without that provenance language.
+
+   There is **no arbitrary file-level marker exemption**: no comment, marker or front-matter
+   key a document can carry will exempt that document, which is why `rk-ident-allow-file` was
+   retired and is now reported as marker abuse. The one file-level skip that does exist is not
+   a marker at all — it is the hard-coded, bot-managed `SKIP_FILES` entry described below,
+   editable only by changing a Python file under review. Three narrow escapes exist, and each
+   is reported when it stops doing work:
+
+   - **Section allowances.** Named per file *and per heading*: the canonical record's
+     "Historical claims, now superseded" section and this record's "Context" section. The
+     canonical record's current-fact sections — identity summary, vendor-declared,
+     repository-observed, panel-versus-component, artifact-observed, physically-unverified —
+     are scanned like any other prose, so mutating a live identity row fails CI. The checker's
+     self-check refuses to let an allowance be attached to a current-fact section, and a
+     section allowance that no longer suppresses anything is a structure failure.
+   - **`rk-ident-allow-next-line`.** For truthful statements about *other* boards. It covers
+     exactly one following prose line, must name the guarded rule, must name the other target,
+     must carry a reason of at least 20 characters, may not name the shipping target, and is
+     rejected if the line it covers does not mention the declared target. It cannot be stacked
+     and cannot reach a second line. Every use is visible in the diff.
+   - **`SKIP_FILES`.** Currently only root `CHANGELOG.md`, because
+     `.github/workflows/changelog.yml` writes GitHub release bodies verbatim into that file
+     and commits them straight to `master`. A violation arriving that way could not be fixed
+     by a documentation edit. The skip is by exact root-level path; the fixture suite asserts
+     that `docs/CHANGELOG.md` and similarly named files are still scanned.
+
+   **The rules are not permanent product policy.** Before a second shipping target or a real
+   encoder-press input is documented, the relevant rules and clean fixtures must be revised or
+   retired so truthful product/input prose does not accumulate line markers. Likewise, the
+   hand-maintained required-document/link list — including the root `README.md`, where a reader
+   first meets the product — intentionally turns a rename or removal into a
+   Python edit. Required links are resolved relative to the referring document and must point to
+   the existing canonical path; a dead path that merely ends in `board.md` fails. That coupling
+   is the cost of making disappearance fail loudly. Issue
+   [#213](https://github.com/muness/roon-knob/issues/213) owns that governance work — revising or
+   retiring the product/input rules and their clean fixtures before a second target or a real
+   encoder-press input is documented — and blocks #205 from making the workflow required. The
+   fail-loud handling of unterminated comments and fences and the observability of `unless`
+   suppressions are **no longer deferred to #213**: both ship here, described above and pinned by
+   fixtures, because each of them was a way for the guard to report green on a document it had
+   not read.
+
+   The workflow is **advisory today** and is a safe candidate for
+   [#205](https://github.com/muness/roon-knob/issues/205) to make required on `master`. Until
+   then a red run is visible on the pull request but does not block a merge. It is a safe
+   candidate specifically because it **always reports**: there is no `paths:` filter, so it runs
+   on every pull request and every push to `master` rather than being *skipped* on changes that
+   touch no Markdown. A required check that can be skipped is a required check that can be
+   bypassed, which is why the path filters an earlier cut carried were removed. The job stays
+   host-only — no ESP-IDF container, no artifacts, `contents: read` only, and its own
+   `concurrency` group — so requiring it adds one short job and no coupling to
+   `docker.yml` or to unmerged release-config work in PR #204.
+
+   **Advisory red decays**, and that is a real cost rather than a neutral state: a check nobody
+   has to pass is a check people learn to scroll past, and this one is deliberately loud. No review
+   date is recorded here. An earlier draft set one; it was removed on review, because a date in a
+   Markdown file and a workflow comment enforces nothing, expires without anyone noticing, and
+   reads afterwards as a commitment that was quietly dropped. Whether this job becomes a required
+   status check or is retired on its merits is tracked in
+   [#213](https://github.com/muness/roon-knob/issues/213), which is also what gates #205 — a
+   tracked issue can be scheduled, reassigned and closed; a sentence cannot.
+
+   The workflow's step summary is rendered by `scripts/summarize_docs_identity.py`, not by an
+   inline heredoc. The heredoc version indexed every detail row as `row["rule"]`, which is true
+   of `violations` and false of `marker_abuse`, so the first marker-abuse finding replaced the
+   summary with a `KeyError` — on exactly the runs that needed a summary. The renderer is now a
+   file the fixture suite exercises against a synthetic report carrying all five finding groups
+   plus the informational `suppressions` group at once, and it always exits 0 so it can never mask
+   the checker's own exit code. Findings and informational rows are rendered separately, so a
+   suppression is visible without reading as a failure and a clean run that merely excused
+   something still carries the "nothing found in a known or tested wording" note.
+
+   The report contract is documented alongside the workflow step that produces it: `token` and
+   `exit_code` agree with the step's status; `violations`, `marker_abuse`, `structure_failures`,
+   `missing` and `selfcheck_failures` are findings; `suppressions` is informational; and `rules`
+   is the size of the rule table rather than a coverage figure.
+
+7. **Public compatibility advice is corrected by evidence, not posted unilaterally.** The
+   existing #117 reply describes the target as an "SH8601 (QSPI)" display, which decision 4
+   shows is the software component's name rather than the vendor-declared driver IC.
+
+   No draft reply is committed to this tree, and nothing has been posted to #117. The proposed
+   wording will be included **in the pull request description** for review before that PR is
+   marked ready, so it is read in the same place as the evidence it rests on. The PR description
+   remains durable GitHub review metadata after merge; deliberately not committing the draft
+   avoids shipping an unapproved public response as repository documentation. **Posting it to
+   the issue requires explicit maintainer confirmation**, and this record does not grant it.
+
+   The reply must rest only on facts this record establishes: the vendor declares an ST77916
+   driver IC and the CST816 touch family, the panel is a 360×360 round IPS LCD, and the SoC is
+   an ESP32-S3R8. Both surviving blockers must be stated rather than glossed — the GPIO pin
+   mapping for any other board is unknown to this repository, and this firmware requires a
+   rotary encoder that boards without one do not provide. Earlier guess-shaped language about
+   what "should probably work" does not survive; where a fact is unverified the reply says so.
+
+8. **Repository-observed facts are derived from values and behaviour, never from source
+   comments.** Comments drift; the backlight-duty error described in Context is what that drift
+   looks like when it reaches a provenance record. Every `R` row in the canonical record cites a value, a call, or
+   the absence of a call — the row about the firmware reading no physical button cites the two
+   `gpio_config()` and four `gpio_get_level()` call sites and the absence of any other, not the
+   comment at `platform_input_idf.c:31` that happens to say the same thing. Where a stale
+   comment exists it is named as stale.
+
+9. **Physical and vendor invariants are revisited once #189 produces evidence.** Everything in
+   the canonical record is vendor-declared, repository-observed or artifact-observed; nothing
+   is measured on an owned device. When
+   [#189](https://github.com/muness/roon-knob/issues/189)'s hardware checklist produces
+   readings — `flash-id`, panel and touch markings, module package, encoder shaft, second
+   encoder, PSRAM mode, board revision — the physically-unverified table is re-derived against
+   them, and any vendor declaration they contradict is demoted to a superseded claim by the
+   same process used here. Until then no `U` fact may be restated as verified anywhere.
+
+## Consequences
+
+**Good.** #203 and #193 inherit an attributable baseline instead of a contradiction. Porting
+advice stops sending contributors after the wrong driver IC. The checker turns a relapse *in a
+known or tested wording* into a CI failure instead of a later discovery — which is a smaller
+claim than "makes a relapse a CI failure", and the smaller claim is the true one. Novel phrasings
+still get through; see decision 6 for what is and is not covered, and review identity claims on
+their merits rather than trusting a green check.
+
+**Costs.** The checker guards phrasing, so a legitimate future statement of the superseded panel
+technology, the superseded colour-depth figure, or the software component named as a driver IC
+will fail CI unless it is quoted as source or carries a line allowance. Widened rules widen that
+cost: the colour-depth rule now also reads bit depths and the encoder rule now also reads
+click/push gestures on the knob or dial, so a sentence about a *different* board needs the
+one-line marker where it previously needed nothing. The counterweight is
+`scripts/fixtures/docs_identity/paraphrases_clean.tsv`, which pins fourteen truthful sentences
+that share vocabulary with a guarded phrase and must stay accepted, so a rule cannot drift into a
+topic ban unnoticed. Backticks alone no
+longer buy an exemption: a span is treated as quoted code only when it carries a code signal
+(an underscore, call syntax, statement punctuation, a hex literal, a path, a filename
+extension), so `esp_lcd_sh8601` and `0x36` are code while a bare product or panel name in
+backticks is still an assertion. Widening any exemption is a reviewed change to the checker,
+not a documentation edit. That is deliberate friction: the failure mode being prevented is an
+unqualified assertion.
+
+Source anchors add a second, narrower coupling in the same spirit: an intentional refactor of
+`platform_display_idf.c`, `platform_input_idf.c`, the touch BSP, `Kconfig.projbuild`,
+`idf_component.yml`, `common/ui.c` or `common/bridge_client.c` that *changes* an anchored line turns
+a documentation guard red. Anchoring whole lines widens that surface compared with fragments — a
+rename or a reformat of the initialiser now trips it where two independent substrings would have
+survived — and whitespace-insensitive matching is what buys most of it back, since realignment and
+reflow do not trip anything. It is still friction on firmware work, and the fix is a small edit to
+`SOURCE_ANCHORS` alongside the re-derived row, not a suppression. Anchors are limited to stable,
+positively quotable text for the same reason; anything churn-prone stays out.
+
+The compensating limit is that **moving** an anchored line costs nothing, which is also the layer's
+blind spot: the cited line numbers go stale in silence. That trade is stated above and everywhere
+the check reports, and it is a real gap, not a solved problem.
+
+**Truth-preserving anchor false positives, and the standing rule for them.** Because an anchor
+matches text, an edit that changes *how* a fact is written while leaving the fact intact fails the
+anchor. These are false positives about the claim and true reports about the citation, and they are
+predictable enough to name:
+
+- **The same value written as an expression.** `.freq_hz = 5000,` rewritten as `.freq_hz = 5 * 1000,`
+  is the same 5 kHz timer; the token misses. (A rewrite that also *changes* the value — `50 * 1000`,
+  which is 50 kHz — is a genuine finding, and the row's "5 kHz" would then be wrong. The two look
+  identical to the guard, which is exactly why the remedy is to re-read rather than to re-green.)
+- **A reordered multi-line stanza.** `BACKLIGHT_KCONFIG_DEFAULT` pins
+  `config RK_BACKLIGHT_NORMAL` with its `int`, `default 100` and `range 0 255` as one block, because
+  `default 100` and `range 0 255` also appear under sibling symbols and only the stanza proves which
+  symbol they belong to. Swapping `default` and `range` — Kconfig does not care — breaks the token
+  while changing nothing about the symbol.
+- Same class, different surface: renaming an anchored macro, splitting a designated initialiser
+  across lines in a way whitespace-insensitivity cannot absorb, or replacing a literal with a
+  `#define` that evaluates to it.
+
+**The standing rule is: re-derive the row from the source and rewrite the token to the new text.
+Never delete an anchor merely to go green.** Deleting the anchor is the one repair that removes the
+evidence instead of refreshing it, and it is cheap, local and invisible in a passing run — which is
+what makes it worth naming here rather than trusting to instinct. A row whose citation cannot be
+re-derived is a row to re-derive or retire in the canonical record, not an anchor to drop.
+
+Shrinkage of the anchor table is **already visible**, and deliberately visible as a floor rather than
+as coverage: the fixture suite asserts at least thirteen anchors and asserts four named ids
+(`QSPI_PINS`, `PANEL_INIT_ARRAY`, `ZONE_PICKER_TOUCH_ENTRY`, `ZONE_PICKER_HANDLER`) are present, so
+removing an anchor fails the suite until someone also edits the floor — a diff line that has to be
+defended, exactly like updating the suppression fingerprint. That floor says nothing about how many
+repository-observed rows exist or are covered; it says the table has not quietly shrunk. The two
+claims are different, and only the second is made.
+
+Pinning the suppression fingerprint is friction of the same kind, and is the sharper of the two:
+adding one legitimately qualified sentence to the documentation will fail the fixture suite until
+someone updates a constant — including when it takes an excuse the baseline already lists, since the
+per-triple count moves. Excluding line numbers and matched prose keeps that from firing on
+unrelated edits, but a genuine new suppression still stops the suite. That is the cost of making an
+invisible widening visible at all, and it is a review conversation rather than a claim about the
+prose.
+
+The local route is a direct command, `python3 scripts/check_docs_identity.py --self-check`, which
+costs a contributor the memory of one line — or a glance at `AGENTS.md` or
+`docs/dev/DEVELOPMENT.md`. It is not wired into `scripts/ci_sanity.sh`, so nothing runs it
+automatically before a commit; that is the honest cost of not pretending a toolchain-dependent
+script is a host-only gate.
+
+The required-document/link list also couples an intentional document rename or removal to the
+checker. That is deliberate while there is one shipping target: disappearance cannot look like
+success. It must be revisited with the product/input rules under #213 before multi-target or
+encoder-press support makes those assumptions false.
+
+The retired `rk-ident-allow-file` marker is now itself a reported violation wherever it appears,
+so the earlier file-level escape cannot return by copy-paste.
+
+**Deliberately not decided here.** Flash geometry and size headroom (#203); managed-component
+pinning and a committed dependency lock (#203); target-profile schema, runtime mismatch
+enforcement, OTA policy, and web-flasher gating (#190, #200); the release-blocking hardware
+checklist (#189); multi-target and encoder-press rule governance, and the fixtures that must be
+revised with it (#213); required status checks on `master` (#205).
+
+### What this does to #213 — a part, not a close
+
+Source anchors and the suppression fingerprint deliver **part** of
+[#213](https://github.com/muness/roon-knob/issues/213): some source-freshness checking, and
+suppression governance with a reviewable baseline. They do **not** satisfy #213 and must not be
+taken as closing it. #213 still owns, unchanged:
+
+- **Line-citation drift.** Anchors check text, never the `:NN` a row cites, so pure line movement
+  leaves citations stale with the guard green. Nothing here addresses it.
+- **Unanchored `R` rows.** Negative and uniqueness claims, derived counts, diffs against the vendor
+  archive, and every physical fact stay human-derived. The anchor table is a subset by design.
+- **Anchor false positives are maintenance, not #213 work.** A truth-preserving rewrite of an
+  anchored line — an expression form of the same value, a reordered Kconfig stanza — fails the anchor
+  while the fact stands. The standing rule in *Consequences* applies now and needs nothing from #213:
+  re-derive the row, rewrite the token, never delete the anchor to go green. It is listed here only
+  so nobody defers a five-minute repair to an open issue, and so nobody reads "the anchor was
+  removed" as "#213 will get to it".
+- **Branch and alternation evidence.** Each rule is an alternation and each fixture proves one
+  clause fires; the rule count is still not a coverage number, and unexercised clauses are still
+  untested.
+- **Multi-target fixtures.** Everything here assumes one shipping target. A second target needs the
+  fixtures and the rules revised together.
+- **Input-rule evolution.** The encoder/button rules encode "this firmware reads no button". A real
+  encoder-press input makes truthful prose fail until those rules are revised or retired.
+- **Required-document rename governance.** The hand-maintained required-document and link lists
+  still turn an intentional rename or removal into a Python edit.
+- **Whether this workflow becomes required or is retired**, which also gates #205.
+
+The two things that were previously deferred to #213 and *are* discharged here are the fail-loud
+handling of unterminated comments and fences, and the observability of `unless` suppressions.
+
+## Alternatives rejected
+
+- **A new `TARGET_IDENTITY.md`.** Rejected: two identity files is the defect, not the fix.
+- **Wait for physical inventory.** Rejected: it leaves a wrong record published and blocks
+  #203 on facts #203 does not need.
+- **Call `esp_lcd_sh8601` a transport shim.** Rejected as overstated in the other direction —
+  the component performs real DCS setup before the vendor array.
+- **Prose-only correction with no check.** Rejected: the contradiction had already survived
+  many edits across nine files, which is the signature of something diff review does not
+  catch.
+- **A file-level exemption for the two records that quote superseded claims.** Rejected on
+  review: it left the canonical record's own current facts unscanned, which is the one file
+  where a relapse matters most. Replaced by per-section allowances plus a per-line
+  other-target marker.
+- **Narrowing the scan to `docs/**`.** Rejected: identity claims live in root `README.md`,
+  `AGENTS.md`, `CLAUDE.md`, `.github/RELEASE_TEMPLATE.md` and analysis notes too. The scan is
+  repo-wide, with one named bot-managed exception.
+- **Triggering the workflow on `paths: ['**/*.md', ...]`.** Rejected on review: a filtered job is
+  *skipped*, not green, on pull requests that touch nothing it matches, and a required status
+  check that can be skipped can be bypassed. The job is short and host-only, so it runs
+  unconditionally instead.
+- **Excluding every dot-directory from the scan.** Rejected: it made the documented scope and the
+  real scope disagree, and it silently exempted `.github/RELEASE_TEMPLATE.md`, which is release
+  prose about the target. Directories are now excluded only by exact name.
+- **Rendering the CI step summary from a heredoc in the workflow.** Rejected: CI-only code is
+  untested code, and this particular heredoc crashed with a `KeyError` on the first marker-abuse
+  finding. It is a tested script now.
+- **Treating any fence-shaped line as a fence toggle, and letting an unclosed comment or fence
+  absorb the rest of a file.** Rejected: it made the widest exemption the checker has depend on a
+  boolean that Markdown does not agree with, and both shapes let a document report green on prose
+  the scan never read. Fences are matched CommonMark-shaped and an unclosed opener of either kind
+  is a structure failure naming its line.
+- **Making an unterminated comment or fence a `VIOLATION` rather than a `STRUCTURE` failure.**
+  Rejected: the defect is that the scan could not see the document, not that a particular sentence
+  was found in it, and `STRUCTURE` is the rank that already means "could not determine". It also
+  outranks `VIOLATION`, which is the correct precedence for a state that hides violations.
+- **Leaving `unless` suppressions implicit, or making a suppressed hit fail.** Both rejected. Left
+  implicit, widening a suppressor shrinks the guard with no trace in any report; made a failure,
+  truthful qualified prose — a pixel-format note, a datasheet reference — could not be written at
+  all. Suppressions are recorded and reported, and the exit code stays 0.
+- **Anchoring the canonical record's negative rows** — "no physical button is read anywhere",
+  "no 128 literal exists in the file". Rejected: an absence cannot be established by asserting a
+  token. Requiring a token would prove nothing about the rest of the tree, and its disappearance
+  would prove nothing at all, so the anchor would be theatre attached to the rows that most need
+  real derivation. Those rows stay human-derived, and the checker's docstring says why.
+- **Treating a source anchor as evidence the fact is true.** Rejected as exactly the conflation
+  this record exists to prevent: source text and physical silicon are different provenance classes,
+  and a `grep` cannot promote one to the other. An anchor asserts only that the citation is still
+  fresh, and its failure wording says "re-read the source", never "the claim is false".
+- **Parsing the anchored sources instead of matching tokens.** Rejected: a C or Kconfig parser is a
+  large dependency and a large maintenance surface for a check whose job is to notice that a cited
+  line changed. Tokens are legible in review.
+- **Splitting a whitespace-sensitive line into the fragments that do not move.** Rejected on review,
+  having been the first cut. `PIN_NUM_BK_LIGHT` and `((gpio_num_t)47)` as two tokens are both
+  satisfied by a file in which the name and the number no longer describe each other, so the anchor
+  would certify a relationship it had not checked. Whole lines and whole blocks are pinned instead,
+  and matching is made whitespace-insensitive so alignment is not what the assertion rests on.
+  `--self-check` now refuses a bare identifier or literal as a token.
+- **Asserting the line numbers the `R` rows cite.** Rejected: every unrelated edit above a cited
+  line would turn a documentation guard red, and a guard that fails for reasons unrelated to its
+  subject gets deleted or ignored. The consequence — line-citation drift is invisible here — is
+  stated in the checker, the findings, the report, the summary, the workflow and the fixtures rather
+  than papered over, and remains #213's.
+- **Reporting `anchors_fresh` as though it were coverage of the `R` rows.** Rejected as the same
+  overstatement the rule count already had to have removed from it. The anchor table is a subset;
+  negative, uniqueness, derived and physical rows cannot be anchored. The report carries the
+  checker's own scope note, the step summary renders it beneath the count, and the fixture suite
+  asserts a floor rather than an equality.
+- **Pinning the suppression *total*, or making a suppression fail the checker.** Both rejected. A
+  scalar total cannot see one suppressor swapped for another at an unchanged total, which is what a
+  widening looks like once a suppressed line is also removed; making a suppression fail would mean
+  truthful qualified prose could not be written at all. An exact `rule|file|suppressor|count`
+  fingerprint is pinned in the fixture suite instead — excluding line numbers and matched prose so it
+  does not churn, and counting per triple so an already-listed excuse is not a licence for further
+  hits — so the consequence is a review conversation and the checker's own exit contract is
+  unchanged.
+- **Deriving the fingerprint's shape proofs from the live suppression set.** Rejected on review,
+  having been the first cut. The control proving the fingerprint ignores line numbers and matched
+  prose compared the live fingerprint against the pinned constant, so a legitimate new suppression
+  failed it too — reporting a false "the fingerprint is broken" alongside the true "the baseline
+  moved". The proofs run against a fixed synthetic set now, so one cause produces one failure.
+- **Exempting four-space indented blocks as code.** Rejected: telling an indented code block from a
+  continuation line needs list and blockquote context, and an indentation-only exemption would exempt
+  the reflowed middle of a paragraph — including the indented renderings the wrap audit uses, which
+  are the guard's only recall evidence. Indented blocks stay scanned, and the cost is paid in
+  discoverability instead: every violation report names the remedy, and a fixture pins that the remedy
+  works.
+- **Leaving the guard reachable only from CI.** Rejected: contributors would first meet it as a red
+  pull request. The local route is the direct command, named in `AGENTS.md` and
+  `docs/dev/DEVELOPMENT.md`. No global or per-user agent instruction was added — the repository's own
+  files are the right scope.
+- **Wiring the guard into `scripts/ci_sanity.sh` and calling that the local gate.** Rejected on
+  review, having also been the first cut. That script's next step is `idf.py build`, so it cannot
+  run on a host without ESP-IDF — the host this check exists for — and no workflow invokes it, so
+  "the local gate" was a claim about a script that is not demonstrably live. The fixture suite pins
+  the direct command and the phrase both documents use instead.
+- **Recording a calendar date for reviewing the advisory status.** Rejected: a date in a Markdown
+  file and a workflow comment enforces nothing and expires unnoticed, leaving a commitment that
+  reads as abandoned. #213 tracks it, because an issue can be scheduled and closed.
+- **Extend an existing workflow.** Rejected: `.github/workflows/docker.yml` is owned by open
+  PR [#204](https://github.com/muness/roon-knob/pull/204), and a docs check has no reason to
+  depend on a firmware container.

--- a/scripts/check_docs_identity.py
+++ b/scripts/check_docs_identity.py
@@ -1,0 +1,1885 @@
+#!/usr/bin/env python3
+"""Phrase tripwire for the known round-target identity contradictions.
+
+Issue #211. Offline, standard library only, no network, no repository writes.
+
+Two jobs:
+
+1.  Scan Markdown across the repository for the specific identity contradictions
+    that #211 corrected: wrong product name, AMOLED panel, 16.7M/24-bit colour
+    depth, absent or always-on backlight, the stale 50 % backlight-duty figure,
+    SH8601 named as the panel's driver IC, module-package claims, an encoder push
+    button, and an unqualified touch-variant part.
+
+2.  Assert the canonical record itself still has its provenance structure, still
+    carries the corrected values, and is still linked from every document that
+    would otherwise be tempted to restate identity.
+
+What this check is, and what it is not
+--------------------------------------
+
+Every rule below is a regular expression over normalised prose.  This is a
+**phrase tripwire**, not a semantic or factual check.  Its demonstrated recall,
+for the single-physical-line renderings in the fixtures, is exactly two things:
+
+*   the wordings that were actually present in this repository before #211, each
+    pinned by a rule probe and a fixture; and
+*   the paraphrases listed in ``scripts/fixtures/docs_identity/paraphrases.tsv``,
+    which are authored independently of the rule probes so that "the rule matches
+    its own example" cannot be mistaken for recall.
+
+The paraphrases are independently authored but **fitted**, not held out: the
+rules were widened until all 15 were reported.  The wrap figures below therefore
+measure sensitivity on fitted data, not general recall on unseen wording.
+
+Outside those two sets the check makes **no claim**.  Matching is per physical
+line: breaking a guarded phrase across lines can make it pass, and the
+``CONTROLLER_CLAIM``, ``BACKLIGHT_DUTY`` and ``ENCODER_BUTTON`` rules have no
+single-token clause that survives every such break.  A sufficiently different
+sentence will also pass: prose that never names the guarded token ("the screen
+makes its own light"), a colour depth given only as a hex range, a claim carried
+in an image, a diagram, a translated spec table, or a file this scan does not read.
+
+A reproducible audit estimate applies Python ``textwrap.wrap`` to each of the 15
+paraphrases at every starting column, using initial indentation to represent that
+column, then tests its designated rule against each physical output line.  At 88
+columns, 120 of 1,320 offsets (9.1 %) are missed: ``BACKLIGHT_DUTY`` 20/88,
+``CONTROLLER_CLAIM`` 49/264, ``ENCODER_BUTTON`` 40/264, ``COLOR_DEPTH`` 7/176,
+``PANEL_AMOLED`` 4/88, and zero for the other rules.  At 100 columns the same 120
+misses are 8.0 % of 1,500 offsets.  This is a sensitivity baseline, not a recall
+guarantee; #213 owns the formal audit and any mechanism change.
+So a relapse is *not* guaranteed to become a CI failure -- only a relapse in a
+known or tested wording is.  Human review of identity claims is still required;
+this check exists to make the cheap relapses loud and to make any widening of the
+exemptions a reviewed change to this file rather than a documentation edit.
+
+**The rule count is not a coverage number.**  Each rule below is an alternation of
+several clauses, and the per-rule fixture proves that *one* clause fires -- not
+that every clause does.  Nothing here claims that the number of rules equals the
+number of covered alternation branches, and no such equality is asserted or
+tested anywhere.  Individual clauses are pinned only where a paraphrase in the
+corpus happens to exercise them; an unexercised clause is untested, and adding a
+clause does not add evidence of recall.
+
+Scan scope -- stated as mechanisms, because counts drift
+-------------------------------------------------------
+
+*   Every file whose name ends in ``.md``, at any depth below the root, is
+    scanned.  That includes ``.github/**/*.md``: ``.github/RELEASE_TEMPLATE.md``
+    ships release prose that describes the target, so it is documentation for
+    this purpose.
+*   There is **no** dot-directory rule.  A directory is skipped only when its
+    exact name appears in ``SKIP_DIRS`` (version control, interpreter caches,
+    build output, vendored dependencies), so a future ``.notes/`` or ``.docs/``
+    is scanned rather than silently exempt.
+*   ``SKIP_RELPATHS`` skips the fixture corpus by path, because that corpus
+    exists to contain the guarded contradictions.
+*   ``SKIP_FILES`` skips bot-managed files by exact root-level path.
+
+Within a scanned file, two constructs are *not* prose and are therefore not
+scanned.  Both of them can hide the rest of a document, so both fail loudly
+rather than absorbing it:
+
+*   **Fenced code.**  Fences are matched CommonMark-shaped: an opener is a run of
+    at least three backticks or tildes indented no more than three spaces, and a
+    closer must use the *same character*, be *at least as long* as the opener, and
+    carry nothing but whitespace after it.  So a backtick fence cannot be closed
+    by tildes, a three-backtick line cannot close a four-backtick opener, and a
+    ```` ```code``` ```` span on its own line is inline code rather than a fence.
+    Everything between opener and closer is exempt -- quoting the guarded wording
+    as source is legitimate.  An opener that is never closed leaves the tail of
+    the file unscanned, so it is reported as a ``STRUCTURE`` failure naming the
+    file and the opening line.
+*   **HTML comments.**  Comment bodies are stripped before scanning, spanning
+    lines when the comment does.  A ``<!--`` with no matching ``-->`` would
+    swallow every following line, so it too is reported as a ``STRUCTURE``
+    failure naming the file and the opening line.
+
+Neither case can end in ``RK-IDENT-OK``: a malformed fence or comment is a
+structural finding whose exit code outranks a contradiction, precisely because it
+is the state in which a contradiction cannot be seen.
+
+**Indented code is not one of those two constructs: it is scanned as prose.**  A
+four-space indented block is code to CommonMark, and it is deliberately *not*
+exempt here.  Recognising it would mean tracking list and blockquote context to
+tell an indented code block from a continuation line, and an indentation-only
+exemption would exempt the reflowed middle of a paragraph -- including every
+indented rendering the wrap audit above uses to represent a starting column.  So a
+quotation of source that is indented rather than fenced *is* reported as a claim,
+and the remedy is to fence it.  Because that is the one exemption a reader expects
+and does not get, ``QUOTING_NOTE`` is printed with the violation lines of every
+report that has any (``--quiet`` gates it with them), carried in the JSON report,
+and rendered in the CI step summary, so the state is discoverable from the output
+rather than only from here.
+``scripts/fixtures/docs_identity/indented_code_scanned.md`` pins it.
+
+Source anchors -- freshness of a citation, not proof of a fact
+--------------------------------------------------------------
+
+The canonical record's ``Repository-observed`` rows are claims *about this
+repository's source*, each citing a file.  Prose rules cannot notice when the
+cited source moves out from under the prose: the documentation stays word for
+word correct-looking while the thing it was read from is gone.  ``SOURCE_ANCHORS``
+pins the stable, load-bearing, positively quotable ones as explicit
+(file, expected tokens) assertions -- the QSPI pin mapping and its bus/panel-IO
+bindings, the GPIO 47 backlight pin with its LEDC channel, the
+``CONFIG_RK_BACKLIGHT_NORMAL`` duty assignment and the Kconfig stanza behind it,
+the init array's declaration, its ``0x36`` terminator and the ``vendor_config``
+binding that carries it, the ``esp_lcd_new_panel_sh8601`` call and the
+``bits_per_pixel`` of the config it is given, the encoder A/B pin definitions with
+the ``gpio_config``/``gpio_get_level`` sites that use them, the ``0x15`` touch
+address and the 7-byte register read, the unpinned ``esp_lcd_sh8601`` dependency,
+and the zone picker's click registration, emitter, handler and default label
+literal.  A missing file or a missing token is a named ``STRUCTURE`` finding,
+because it is a state in which the record's citation can no longer be checked.
+
+**Tokens must carry their own relationship.**  A token is matched
+whitespace-insensitively (every run of whitespace in the token matches any run in
+the file, so realignment and reflow do not break it) and with word-boundary
+guards at each end (so ``0x15`` does not match ``0x152`` and ``GPIO_NUM_8`` does
+not match ``GPIO_NUM_80``).  That is what makes it safe to pin whole lines and
+whole blocks, and pinning them is the point: a *split* pair of tokens such as
+``PIN_NUM_BK_LIGHT`` and ``((gpio_num_t)47)`` is satisfied by a file in which the
+name and the number have drifted apart onto different lines, so it would report a
+fresh citation for a relationship that no longer exists.  Every token therefore
+states the relationship it is cited for -- ``#define PIN_NUM_BK_LIGHT
+((gpio_num_t)47)``, not the two halves separately -- and ``--self-check`` rejects a
+token that is a bare identifier or bare literal for exactly that reason.
+
+**What an anchor does and does not establish.**  A present token proves only that
+the cited text is still in the cited file.  It is *not* evidence that the physical
+board behaves that way, that the value is correct, or that the surrounding claim
+is true -- board.md's provenance classes exist precisely because source text and
+silicon are different kinds of evidence.  Conversely, a *missing* token means the
+citation has drifted and must be re-read; it is **not** a finding that the claim is
+false.  The finding wording says so, and the remedy is to re-derive the row from
+the source, not to delete the row.
+
+**Anchors do not validate the line numbers a row cites.**  The rows cite lines --
+``platform_display_idf.c:55`` -- ``:61`` -- and an anchor checks *text*, never a
+line number.  Insert forty lines above an anchored block and every token is still
+present, every anchor still reports fresh, and every ``:NN`` in the Markdown is now
+wrong.  Pure line movement is therefore *invisible* to this layer by construction.
+Deliberately so: asserting line numbers here would turn every unrelated edit above
+a cited line into a red documentation guard, which is the brittleness that gets a
+check deleted.  Keeping the cited lines correct is human-review work, tracked in
+`#213 <https://github.com/muness/roon-knob/issues/213>`_.
+
+**The anchor count is not a coverage number.**  ``SOURCE_ANCHORS`` covers a
+deliberate *subset* of the repository-observed rows.  ``anchors_fresh=N/N`` means
+every anchor in the table is fresh -- it does **not** mean every repository-observed
+row is anchored, and no equality between the two is asserted anywhere.  Rows stay
+unanchored for two reasons.  First, **negative** rows: "no physical button is read
+anywhere in the firmware" and "no 128 literal exists in the file and no code path
+implements the stale 50 % claim" are absence claims, and no token assertion can
+establish an absence -- a token's
+presence would prove nothing about everywhere else, and its absence would prove
+nothing at all.  Uniqueness rows ("the *only* emitter of ``UI_INPUT_MENU``") are
+absence claims too.  Second, **derived or physical** rows: the 185-entry and
+146-distinct-opcode counts come from reading the array, the demo-archive diff and
+the ``difflib`` similarity figures come from files outside this repository, and no
+row about the silicon is anchorable at all.  Those stay derived by human reading.
+
+Rule-level suppressions are observable, not silent
+--------------------------------------------------
+
+Some rules carry an ``unless`` suppressor so that truthful qualified prose passes:
+"RGB888 is a 24-bit pixel format" is not a claim about the panel, and "the
+datasheet Waveshare links describes the CST816D" is not a claim about the fitted
+part.  Every hit a suppressor swallows is *recorded* -- with file, line, rule id,
+the matched text and the suppressor text that excused it -- and surfaced in the
+JSON report (``suppressions``), in the summary counters (``suppressed=``), in an
+informational ``RK-IDENT-SUPPRESSED`` line per hit, and in the CI step summary.
+Suppressions do not change the exit code: a run whose only findings are
+suppressions is still ``RK-IDENT-OK`` and still exit 0.  Their visibility is the
+point -- a widened suppressor shows up as a growing suppression list in review
+instead of as a quietly shrinking guard.  ``--self-check`` replays each rule's
+``probe_exempt`` through the scanner and fails if the suppressed hit is not
+recorded, so removing that observability cannot pass silently.
+
+Exemptions are deliberately narrow, because a wide one is how the original
+contradiction survived nine files of review:
+
+*   ``SECTION_ALLOWANCES`` names individual *sections* of individual files where
+    restating a superseded claim is the whole point of the prose.  There is no
+    file-level *marker* opt-out -- no comment a document carries exempts that
+    document -- and the canonical record's own current-fact sections are scanned
+    like any other document, so mutating a live row in its identity table fails
+    the check.  The one file-level skip is ``SKIP_FILES`` below, which is
+    hard-coded here rather than assertable from a document.
+*   ``rk-ident-allow-next-line`` covers exactly one following prose line, must
+    name the guarded rule, must name the *other* target the line is about, and
+    must carry a reason.  It cannot be used for the shipping target, cannot
+    cover a line that does not mention the declared other target, cannot be
+    stacked, and is reported if it stops suppressing anything.
+*   ``SKIP_FILES`` names bot-managed files, currently only ``CHANGELOG.md``.
+
+Exit contract -- every "could not determine" state is non-zero and named:
+
+    0   RK-IDENT-OK           no guarded contradiction found in a known wording
+    1   RK-IDENT-VIOLATION    a guarded contradiction is present
+    2   RK-IDENT-STRUCTURE    canonical record, links, allowances or a source anchor
+                              degraded, or a document's comment/fence structure hid
+                              part of itself
+    3   RK-IDENT-MISSING      a required file is absent, or nothing was scanned
+    4   RK-IDENT-SELFCHECK    the checker's own rules failed self-verification
+    64  RK-IDENT-USAGE        bad invocation
+
+``RK-IDENT-SUPPRESSED`` is informational only and has no exit code of its own.
+
+Precedence is MISSING > SELFCHECK > STRUCTURE > VIOLATION.  Outranked tokens are
+still printed, so a structure failure never hides a contradiction.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+
+TOOL = "check_docs_identity"
+VERSION = "2.6.0"
+
+EXIT_OK = 0
+EXIT_VIOLATION = 1
+EXIT_STRUCTURE = 2
+EXIT_MISSING = 3
+EXIT_SELFCHECK = 4
+EXIT_USAGE = 64
+
+TOKEN_OK = "RK-IDENT-OK"
+TOKEN_VIOLATION = "RK-IDENT-VIOLATION"
+TOKEN_STRUCTURE = "RK-IDENT-STRUCTURE"
+TOKEN_MISSING = "RK-IDENT-MISSING"
+TOKEN_SELFCHECK = "RK-IDENT-SELFCHECK"
+TOKEN_USAGE = "RK-IDENT-USAGE"
+TOKEN_MARKER_ABUSE = "RK-IDENT-MARKER-ABUSE"
+# Informational only: a suppression is a hit a rule's `unless` clause excused. It
+# is printed and reported so the excuse is visible, and it never changes the exit
+# code -- see the module docstring.
+TOKEN_SUPPRESSED = "RK-IDENT-SUPPRESSED"
+
+# Printed with every violation report, carried in the JSON report and rendered in
+# the CI step summary. A four-space indented block is CommonMark code but is
+# scanned here as prose -- see the module docstring -- so it is the one exemption a
+# reader expects and does not get. The remedy travels with the finding instead of
+# living only in documentation nobody reads while staring at a red run.
+QUOTING_NOTE = (
+    "quote source in a fenced code block (``` ... ```) if it is a quotation, not a "
+    "claim: a four-space indented block is scanned as prose, not exempted as code, "
+    "so indented source is reported here"
+)
+
+CANONICAL = "docs/esp/hw-reference/board.md"
+ADR = "docs/meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md"
+DOCS_INDEX = "docs/README.md"
+
+# The shipping target. An other-target allowance may not name it.
+SHIPPING_TARGET = "ESP32-S3-Knob-Touch-LCD-1.8"
+
+# Retired: the first cut of this checker exempted whole files via this marker,
+# which meant the canonical record's own current facts were never scanned. The
+# marker is now a violation wherever it appears, so the old escape cannot come
+# back by copy-paste.
+RETIRED_MARKER = "rk-ident-allow-file"
+
+ALLOW_NEXT_NAME = "rk-ident-allow-next-line"
+MIN_REASON_CHARS = 20
+
+# Directories never scanned, by exact name at any depth.  This list is the *only*
+# directory exclusion: `find_markdown` has no dot-directory rule, so `.github` is
+# scanned like any other directory and a future `.notes/` cannot become exempt by
+# accident.  Everything named here is either version control, an interpreter or
+# tool cache, build output, or a vendored dependency tree -- never authored prose.
+SKIP_DIRS = frozenset(
+    {
+        # version control
+        ".git",
+        # interpreter and tool caches
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "venv",
+        # build output
+        "build",
+        # vendored dependencies
+        "managed_components",
+        "node_modules",
+        "dependencies",
+    }
+)
+
+# Directories that must stay scannable.  `.github` held identity prose in
+# `RELEASE_TEMPLATE.md` while an earlier cut of this checker excluded every
+# dot-directory, so the documented scope and the real scope disagreed.  Self-check
+# refuses to let that return.
+MUST_SCAN_DIRS = (".github",)
+
+# Directories never scanned, by path relative to the root.  The fixture corpus
+# deliberately contains the guarded contradictions -- that is what it is for --
+# so scanning it would make the check permanently red.
+SKIP_RELPATHS = ("scripts/fixtures",)
+
+# Bot-managed files, skipped by exact repo-relative path.
+#
+# CHANGELOG.md: `.github/workflows/changelog.yml` fires on `release: published`,
+# writes `github.event.release.body` verbatim into CHANGELOG.md, and commits it
+# straight to master. A release body is quoted history written by a bot, not a
+# documentation claim about the board, and a violation arriving that way could
+# not be fixed by a documentation edit -- master would simply be red. Named per
+# file, root-level only (self-check enforces the absence of a path separator),
+# and the fixture suite asserts that neither `docs/CHANGELOG.md` nor any
+# similarly named file inherits the skip.
+SKIP_FILES = ("CHANGELOG.md",)
+
+# Documents that carry identity-adjacent subject matter and must therefore point
+# at the canonical record instead of restating it.
+REQUIRE_CANONICAL_LINK = (
+    "README.md",
+    DOCS_INDEX,
+    "docs/dev/DEVELOPMENT.md",
+    "docs/dev/IMPLEMENTATION_NOTES.md",
+    "docs/esp/DISPLAY.md",
+    "docs/esp/DUAL_CHIP_ARCHITECTURE.md",
+    "docs/esp/ROTARY_ENCODER.md",
+    "docs/esp/TOUCH_INPUT.md",
+    "docs/esp/hw-reference/COLORTEST_HELLOWORLD.md",
+    "docs/esp/hw-reference/HARDWARE_PINS.md",
+    "docs/esp/hw-reference/RGB565_IMPLEMENTATION.md",
+    "docs/esp/hw-reference/cst816d.md",
+    "docs/esp/hw-reference/encoder.md",
+    "docs/esp/hw-reference/touch.md",
+    "docs/howto/PORTING.md",
+)
+
+# Headings the canonical record must keep, in this order, so its provenance
+# separation cannot be flattened back into an undifferentiated spec sheet and so
+# the one allowed historical section cannot be widened by deleting the heading
+# that ends it.
+CANONICAL_SECTIONS = (
+    "## How to read this record",
+    "## Identity summary",
+    "## Vendor-declared facts",
+    "## Repository-observed facts",
+    "## Panel controller versus software driver",
+    "## Release-artifact-observed facts",
+    "## Historical claims, now superseded",
+    "## Still requires physical inspection",
+)
+
+# Sections of the canonical record that state what is true *now*. These are
+# scanned for contradictions like any other prose; self-check asserts none of
+# them is ever granted a section allowance.
+CANONICAL_CURRENT_FACT_SECTIONS = (
+    "## Identity summary",
+    "## Vendor-declared facts",
+    "## Repository-observed facts",
+    "## Panel controller versus software driver",
+    "## Release-artifact-observed facts",
+    "## Still requires physical inspection",
+)
+
+# Section-scoped allowances: file -> headings whose prose may restate superseded
+# claims because recording them is the section's purpose. Anything outside these
+# exact sections in these exact files is scanned.
+SECTION_ALLOWANCES = {
+    CANONICAL: ("## Historical claims, now superseded",),
+    ADR: ("## Context",),
+}
+
+# A section allowance may only be granted to a section whose declared job is
+# historical narration. Self-check pins the vocabulary so a future edit cannot
+# quietly move an allowance onto a current-fact section.
+ALLOWED_SECTION_WHITELIST = frozenset(
+    {
+        "## Historical claims, now superseded",
+        "## Context",
+    }
+)
+
+# The five provenance classes must all remain named in the legend.
+CANONICAL_CLASSES = (
+    "Vendor-declared",
+    "Repository-observed",
+    "Artifact-observed",
+    "Historical",
+    "Physically unverified",
+)
+
+# Corrected values whose disappearance would mean the record was gutted rather
+# than merely reworded.
+CANONICAL_VALUES = (
+    "ESP32-S3-Knob-Touch-LCD-1.8",
+    "ESP32-S3R8",
+    "ESP32-U4WDH",
+    "ST77916",
+    "esp_lcd_sh8601",
+    "262",
+    "IPS LCD",
+    "GPIO 47",
+    "CONFIG_RK_BACKLIGHT_NORMAL",
+)
+
+
+# A token is matched whitespace-insensitively and with word-boundary guards. See
+# the module docstring, "Tokens must carry their own relationship": the point of
+# both is that a whole line or whole block can be pinned as one token, so the token
+# states the *relationship* it is cited for instead of leaving it to a pair of
+# independently-satisfiable fragments.
+_TOKEN_WORD = re.compile(r"[0-9A-Za-z_]")
+
+# A token that is only an identifier or only a literal cannot state a relationship,
+# and is the shape that produces a split-token false positive. `--self-check`
+# refuses it.
+_BARE_TOKEN = re.compile(r"\A(?:[A-Za-z_][0-9A-Za-z_]*|0[xX][0-9A-Fa-f]+|[0-9]+)\Z")
+
+
+def anchor_pattern(token):
+    """Compile one expected token, or return ``None`` if it holds no text.
+
+    Whitespace in the token matches any run of whitespace in the file, so the
+    token survives realignment and reflow and may span lines -- which is what
+    makes a multi-line block usable as a single relationship-preserving token.
+
+    The gap between two of the token's whitespace-separated parts is matched
+    *precisely* as follows, because "whitespace-insensitive" alone is ambiguous
+    about whether a gap may close entirely:
+
+    *   ``\\s+`` -- whitespace is **required** -- when the character before the
+        gap and the character after it are both word characters
+        (``[0-9A-Za-z_]``).  Dropping it there would fuse two identifiers or
+        literals into one, so ``#define PIN_NUM_LCD_CS`` must never be satisfied
+        by ``#definePIN_NUM_LCD_CS``.
+    *   ``\\s*`` -- whitespace is **optional** -- when either side of the gap is
+        punctuation.  A formatter may legitimately close such a gap, so
+        ``SH8601_PANEL_IO_QSPI_CONFIG( PIN_NUM_LCD_CS,`` matches both the wrapped
+        call site it was written from and a reflowed
+        ``SH8601_PANEL_IO_QSPI_CONFIG(PIN_NUM_LCD_CS,``.  Without this, an
+        untouched, perfectly accurate citation reports ``missing-token`` purely
+        because someone unwrapped an argument list.
+
+    Word-boundary guards at each end stop a token from matching a longer
+    identifier or literal that merely starts with it (``0x15`` in ``0x152``).
+
+    ``None`` means the token collapsed to nothing.  The matcher treats that as a
+    miss rather than as a pattern that matches everywhere, so a degenerate token
+    fails loudly; ``--self-check`` also names it.
+    """
+    parts = token.split()
+    if not parts:
+        return None
+    pieces = [re.escape(parts[0])]
+    for previous, part in zip(parts, parts[1:]):
+        both_word = _TOKEN_WORD.match(previous[-1]) and _TOKEN_WORD.match(part[0])
+        pieces.append((r"\s+" if both_word else r"\s*") + re.escape(part))
+    body = "".join(pieces)
+    lead = r"(?<![0-9A-Za-z_])" if _TOKEN_WORD.match(token.lstrip()[:1] or " ") else ""
+    trail = r"(?![0-9A-Za-z_])" if _TOKEN_WORD.match(token.rstrip()[-1:] or " ") else ""
+    return re.compile(lead + body + trail)
+
+
+class SourceAnchor:
+    """One repository-observed claim, pinned to the source text it was read from.
+
+    ``path`` is repo-relative.  Each of ``tokens`` must still be found in it, by
+    ``anchor_pattern`` -- whitespace-insensitively, word-boundary guarded, and
+    written so the token itself carries the relationship the row cites.  ``claim``
+    is the canonical-record row the anchor supports, quoted in the finding so a
+    reader knows what to re-derive.
+
+    The assertion is deliberately weak and deliberately explicit: it proves the
+    citation is still fresh, not that the fact is true; it says nothing about the
+    line numbers the row cites; and its failure means "re-read the source", not
+    "the claim is false".  See the module docstring for why no anchor may encode a
+    negative, uniqueness or absence claim, and why the anchor count is not a
+    coverage figure.
+    """
+
+    __slots__ = ("id", "path", "tokens", "claim", "patterns")
+
+    def __init__(self, anchor_id, path, tokens, claim):
+        self.id = anchor_id
+        self.path = path
+        self.tokens = tuple(tokens)
+        self.claim = claim
+        self.patterns = tuple(anchor_pattern(token) for token in self.tokens)
+
+
+# Appended to every anchor finding. The one thing a reader is most likely to
+# assume this layer covers is the one thing it cannot cover.
+ANCHOR_CAVEAT = (
+    "note: an anchor checks text, never the line numbers the row cites, so pure "
+    "line movement leaves a citation stale with every token still present -- that "
+    "is human-review work tracked in #213"
+)
+
+# Printed in the JSON report so the coverage claim travels with the numbers.
+ANCHOR_SCOPE = (
+    "SOURCE_ANCHORS covers a deliberate subset of the canonical record's "
+    "repository-observed rows: the stable, positively quotable ones. "
+    "anchors_fresh=N/N means every anchor in the table is fresh -- NOT that every "
+    "repository-observed row is anchored. Negative and uniqueness rows cannot be "
+    "anchored (a token cannot establish an absence), derived counts and "
+    "outside-the-repository diffs are not quotable text, and no row about the "
+    "silicon is anchorable at all. No anchor validates the line numbers a row "
+    "cites; keeping those correct is human review, tracked in #213."
+)
+
+
+# Stable, load-bearing, positively quotable source text behind the canonical
+# record's `Repository-observed facts` table. Every token states the relationship
+# it is cited for, as a whole line or whole block; see `anchor_pattern`.
+SOURCE_ANCHORS = (
+    SourceAnchor(
+        "QSPI_PINS",
+        "idf_app/main/platform_display_idf.c",
+        (
+            "#define PIN_NUM_LCD_CS ((gpio_num_t)14)",
+            "#define PIN_NUM_LCD_PCLK ((gpio_num_t)13)",
+            "#define PIN_NUM_LCD_DATA0 ((gpio_num_t)15)",
+            "#define PIN_NUM_LCD_DATA1 ((gpio_num_t)16)",
+            "#define PIN_NUM_LCD_DATA2 ((gpio_num_t)17)",
+            "#define PIN_NUM_LCD_DATA3 ((gpio_num_t)18)",
+            "#define PIN_NUM_LCD_RST ((gpio_num_t)21)",
+            # The defines alone would be satisfied by seven dead macros, so the
+            # sites that consume them are anchored too.
+            ".sclk_io_num = PIN_NUM_LCD_PCLK,",
+            ".data0_io_num = PIN_NUM_LCD_DATA0,",
+            "SH8601_PANEL_IO_QSPI_CONFIG( PIN_NUM_LCD_CS,",
+            ".reset_gpio_num = PIN_NUM_LCD_RST,",
+            ".use_qspi_interface = 1,",
+        ),
+        "the QSPI pins are CS 14, PCLK 13, D0-D3 15/16/17/18 and RST 21, and those "
+        "defines are what the SPI bus, the QSPI panel IO and the panel reset are "
+        "configured with",
+    ),
+    SourceAnchor(
+        "BACKLIGHT_GPIO47",
+        "idf_app/main/platform_display_idf.c",
+        (
+            "#define PIN_NUM_BK_LIGHT ((gpio_num_t)47)",
+            ".gpio_num = PIN_NUM_BK_LIGHT,",
+            ".duty_resolution = LEDC_TIMER_8_BIT,",
+            ".freq_hz = 5000,",
+            # The resolution and frequency belong to the timer, the pin to the
+            # channel. Without both halves of the timer<->channel link the anchor
+            # would attribute one struct's values to the other struct's pin.
+            ".timer_num = LEDC_TIMER_0,",
+            ".timer_sel = LEDC_TIMER_0,",
+        ),
+        "the backlight is on GPIO 47 and is driven by an LEDC channel on that pin "
+        "whose timer runs at 8-bit resolution and 5 kHz",
+    ),
+    SourceAnchor(
+        "BACKLIGHT_DUTY_ASSIGNMENT",
+        "idf_app/main/platform_display_idf.c",
+        (".duty = CONFIG_RK_BACKLIGHT_NORMAL,",),
+        "the initial backlight duty is the Kconfig value, not the figure in the stale comment",
+    ),
+    SourceAnchor(
+        "BACKLIGHT_KCONFIG_DEFAULT",
+        "idf_app/main/Kconfig.projbuild",
+        # One block, not three tokens: `default 100` and `range 0 255` also appear
+        # under sibling symbols, so only the stanza proves which symbol they belong
+        # to.
+        (
+            "config RK_BACKLIGHT_NORMAL"
+            ' int "Normal backlight brightness (0-255)"'
+            " default 100"
+            " range 0 255",
+        ),
+        "CONFIG_RK_BACKLIGHT_NORMAL itself declares default 100 within range 0 255",
+    ),
+    SourceAnchor(
+        "PANEL_INIT_ARRAY",
+        "idf_app/main/platform_display_idf.c",
+        (
+            "static const sh8601_lcd_init_cmd_t lcd_init_cmds[] = {",
+            # Terminator: the 0x36 entry immediately followed by the array's
+            # closing brace, which is what makes it the *last* entry.
+            "{0x36, (uint8_t[]){0x00}, 1, 0}, };",
+            ".init_cmds = lcd_init_cmds,",
+            ".init_cmds_size = sizeof(lcd_init_cmds) / sizeof(lcd_init_cmds[0]),",
+            ".vendor_config = &vendor_config,",
+        ),
+        "a project-supplied lcd_init_cmds array is declared, its final entry before "
+        "the closing brace is {0x36, {0x00}, 1, 0}, and it is handed to the panel "
+        "through vendor_config (the 185-entry and 146-distinct-opcode counts are "
+        "derived by reading the array, not anchored here)",
+    ),
+    SourceAnchor(
+        "PANEL_COMPONENT_BINDING",
+        "idf_app/main/platform_display_idf.c",
+        (
+            "const esp_lcd_panel_dev_config_t panel_config = {",
+            ".bits_per_pixel = 16,",
+            "esp_lcd_new_panel_sh8601(s_io_handle, &panel_config, &s_panel_handle)",
+        ),
+        "the panel handle is created by esp_lcd_new_panel_sh8601 from panel_config, "
+        "the one panel dev config in this file, which sets bits_per_pixel = 16",
+    ),
+    SourceAnchor(
+        "ENCODER_PINS",
+        "idf_app/main/platform_input_idf.c",
+        (
+            "#define ENCODER_GPIO_A GPIO_NUM_8",
+            "#define ENCODER_GPIO_B GPIO_NUM_7",
+            ".pin_bit_mask = (1ULL << ENCODER_GPIO_A),",
+            ".pin_bit_mask = (1ULL << ENCODER_GPIO_B),",
+            "gpio_get_level(ENCODER_GPIO_A)",
+            "gpio_get_level(ENCODER_GPIO_B)",
+        ),
+        "encoder channel A is GPIO 8 and channel B is GPIO 7, and both are configured "
+        "as inputs and sampled by gpio_get_level (this anchors the two pins that ARE "
+        "read; the row's claim that no other GPIO is read is an absence claim and is "
+        "not anchored, because no token can establish one)",
+    ),
+    SourceAnchor(
+        "TOUCH_I2C_ADDRESS",
+        "idf_app/components/i2c_bsp/settings.h",
+        ("#define TOUCH_ADDR 0x15",),
+        "the touch controller is addressed at I2C 0x15",
+    ),
+    SourceAnchor(
+        "TOUCH_DEVICE_BINDING",
+        "idf_app/components/i2c_bsp/i2c_bsp.c",
+        ("dev_cfg.device_address = TOUCH_ADDR;",),
+        "TOUCH_ADDR is the address the touch device handle is opened with",
+    ),
+    SourceAnchor(
+        "TOUCH_SEVEN_BYTE_READ",
+        "idf_app/components/lcd_touch_bsp/lcd_touch_bsp.c",
+        (
+            "uint8_t data[7] = {0};",
+            "i2c_read_buff(disp_touch_dev_handle, 0x00, data, 7);",
+        ),
+        "touch state is a raw 7-byte register read from register 0x00 rather than a "
+        "CST816-specific component",
+    ),
+    SourceAnchor(
+        "DRIVER_VERSION_UNPINNED",
+        "idf_app/main/idf_component.yml",
+        # One block: `version: '*'` on its own would be satisfied by any dependency
+        # in the file becoming unpinned, which is a different fact.
+        ("esp_lcd_sh8601: version: '*' public: true",),
+        "the esp_lcd_sh8601 dependency itself is declared unpinned, as version '*'",
+    ),
+    SourceAnchor(
+        "ZONE_PICKER_TOUCH_ENTRY",
+        "common/ui.c",
+        (
+            "lv_obj_add_event_cb(header, zone_label_event_cb, LV_EVENT_CLICKED, NULL);",
+            "static void zone_label_event_cb(lv_event_t *e) {",
+            "s_input_cb(UI_INPUT_MENU);",
+        ),
+        "the zone header registers zone_label_event_cb for LV_EVENT_CLICKED and that "
+        "callback emits UI_INPUT_MENU (the row's claim that it is the *only* emitter, "
+        "and that no encoder input opens the picker, are uniqueness and absence claims "
+        "and are not anchored)",
+    ),
+    SourceAnchor(
+        "ZONE_PICKER_HANDLER",
+        "common/bridge_client.c",
+        (
+            "if (event == UI_INPUT_MENU) {",
+            'cfg->zone_id : "Tap here to select zone",',
+        ),
+        "bridge_client handles UI_INPUT_MENU, and the default zone label is literally "
+        '"Tap here to select zone" when no zone id is configured',
+    ),
+)
+
+
+class Rule:
+    """One guarded contradiction.
+
+    ``probe`` must match the pattern and ``antiprobe`` must not.  A rule with an
+    ``unless`` suppressor must also supply ``probe_exempt``: a line that matches
+    the pattern *and* the suppressor.  ``--self-check`` asserts all of it, plus
+    that the suppressor does not swallow the rule's own probe, so neither half of
+    a rule can rot into a no-op unnoticed.
+    """
+
+    def __init__(self, rule_id, pattern, message, probe, antiprobe, unless=None, probe_exempt=None):
+        self.id = rule_id
+        self.pattern = re.compile(pattern, re.IGNORECASE)
+        self.message = message
+        self.probe = probe
+        self.antiprobe = antiprobe
+        self.unless = re.compile(unless, re.IGNORECASE) if unless else None
+        self.probe_exempt = probe_exempt
+
+
+RULES = (
+    Rule(
+        "PRODUCT_NAME",
+        # Governance trigger: revise or retire before a second shipping target is
+        # documented; this rule guards today's target, not permanent product policy.
+        r"\btouch[\s_-]*amoled\b",
+        "wrong product name; the target is the ESP32-S3-Knob-Touch-LCD-1.8",
+        probe='the Waveshare ESP32-S3 Touch AMOLED 1.8" board',
+        antiprobe="the Waveshare ESP32-S3-Knob-Touch-LCD-1.8 board",
+    ),
+    Rule(
+        "PANEL_AMOLED",
+        # Governance trigger: revise or retire before a second shipping target is
+        # documented; a future target may truthfully carry this panel technology.
+        # The acronym, plus the two spelled-out forms of it. Spelling it out was a
+        # tested way past the acronym-only rule.
+        r"(\bamoled\b"
+        r"|\bactive[\s-]*matrix\s+organic\s+(light[\s-]*emitting\s+diode|led)"
+        r"|\borganic\s+light[\s-]*emitting\s+diode\s+(panel|display|screen)"
+        r"|\borganic\s+led\s+(panel|display|screen))",
+        "the panel is an IPS LCD, not an AMOLED; see the canonical record",
+        probe="360x360 round AMOLED over QSPI",
+        antiprobe="360x360 round IPS LCD over QSPI",
+    ),
+    Rule(
+        "COLOR_DEPTH",
+        # 16.7M, its digit expansion, and the bit-depth form that implies it. The
+        # bit-depth clause is scoped to colour words so that a legitimate note
+        # about a 24-bit pixel format can say so and be exempted below.
+        r"(16\.7\s*(m\b|million)"
+        r"|\b16[,\s]?777[,\s]?216\b"
+        r"|\b24[\s-]*bit\s+(true[\s-]*)?colou?r"
+        r"|\bcolou?r\s+depth\b[^.\n]{0,24}\b24[\s-]*bit\b"
+        r"|\btrue[\s-]*colou?r\s+(panel|display|screen)\b)",
+        "vendor declares 262K colours (18-bit), not 16.7M / 24-bit",
+        probe="1.8 inch round display, 360x360, 16.7M colors",
+        antiprobe="1.8 inch round display, 360x360, 262K colors",
+        # RGB888 really is a 24-bit pixel format, and the repository discusses
+        # pixel formats. Talking about the format is not a claim about the panel.
+        unless=r"(rgb888|rgb24|pixel\s+format|framebuffer\s+format|superseded|historical)",
+        probe_exempt="RGB888 is a 24-bit colour pixel format; the panel still declares 262K colours",
+    ),
+    Rule(
+        "NO_BACKLIGHT",
+        # "no backlight" in its common qualifier forms, the self-illumination
+        # claims that imply it, and the "so there is nothing to dim" corollary.
+        r"(\bno\s+(?:\w+\s+){0,2}backlight\b"
+        r"|backlight[^.\n]{0,40}always\s+on"
+        r"|\bself[-\s]*(emitting|emissive|lit|illuminated|illuminating)\b"
+        r"|backlight\s+control\s+(is\s+)?not\s+needed"
+        r"|\bno\s+(?:\w+\s+){0,2}(dimming|brightness)\s+(control|adjustment)"
+        r"|\bno\s+dimming\b"
+        r"|brightness\s+is\s+fixed"
+        r"|(dimming|brightness)[^.\n]{0,30}\b(is\s+)?not\s+(possible|supported|available)\b)",
+        "there is a PWM backlight on GPIO 47; the firmware drives it",
+        probe="No PWM backlight control needed (AMOLED is self-emitting)",
+        antiprobe="Backlight, LEDC PWM, 8-bit duty on GPIO 47",
+    ),
+    Rule(
+        "BACKLIGHT_DUTY",
+        # The figure as a percent sign, as words, and spelled "per cent".
+        r"((\b50\s*%|\b50\s+per\s?cent\b|\bfifty[\s-]*per\s?cent\b)[^.\n]{0,40}(duty|brightness)"
+        r"|(duty|brightness)[^.\n]{0,40}(\b50\s*%|\b50\s+per\s?cent\b|\bfifty[\s-]*per\s?cent\b))",
+        "the initial backlight duty is CONFIG_RK_BACKLIGHT_NORMAL, whose Kconfig default is "
+        "100/255 (about 39%); the 50% figure is a stale source comment",
+        probe="Backlight on GPIO 47, started at 50 % duty",
+        antiprobe="Backlight on GPIO 47, initial duty CONFIG_RK_BACKLIGHT_NORMAL (100/255)",
+        unless=r"\b(stale|superseded|historical|comment)\b",
+        probe_exempt=(
+            "The stale comment says the backlight starts at 50 % duty; "
+            "the configured value is 100/255."
+        ),
+    ),
+    Rule(
+        "CONTROLLER_CLAIM",
+        # SH8601 asserted as the physical part: as a driver/panel IC (either word
+        # order, with room for an intervening clause), as silicon/a die, or
+        # attributed to Sitronix.
+        #
+        # The long-distance clauses anchor on `\bsh8601`, which cannot match inside
+        # `esp_lcd_sh8601` (no word boundary after an underscore).  Naming the
+        # software component in prose is the corrected wording; a bare SH8601 near
+        # "driver IC" is the assertion.  The two original short-distance clauses
+        # keep their unanchored form, so `esp_lcd_sh8601 controller` still trips.
+        r"(sh8601[\s_-]*(amoled|lcd\b|display\s+controller|controller\b)"
+        r"|\bsh8601[^.\n]{0,60}\b(display|panel|driver)\s+(ic|controller)\b"
+        r"|\b(display|panel|driver)\s+(ic|controller)\b[^.\n]{0,60}\bsh8601"
+        r"|\bsh8601[^.\n]{0,30}\b(silicon|die|part\s+number)\b"
+        r"|\b(silicon|die|part\s+number)\b[^.\n]{0,30}\bsh8601"
+        r"|\bsh8601[^.\n]{0,40}\bsitronix\b"
+        r"|\bsitronix\b[^.\n]{0,40}\bsh8601"
+        r"|sh8601[^.\n]{0,24}expects)",
+        "SH8601 is the software component name; the vendor declares an ST77916 driver IC",
+        probe="| Display controller | SH8601 | QSPI |",
+        antiprobe="| Panel driver component | esp_lcd_sh8601 | QSPI |",
+    ),
+    Rule(
+        "MODULE_CLAIM",
+        # WROOM with any or no separators, and the bare WROOM-1 package name, so
+        # "ESP32S3 WROOM 1" and "ESP32-S3 WROOM1" are not free passes.
+        r"(\besp32[\s_-]*(s3)?[\s_-]*wroom(?:[\s_-]*\d+)?\b"
+        r"|\bwroom[\s_-]*1\b)",
+        "module package is unverified; name the vendor-declared SoC (ESP32-S3R8 / ESP32-U4WDH)",
+        probe="ESP32-S3 | ESP32-S3-WROOM-1 (R8) | BLE 5.0 only",
+        antiprobe="Primary | ESP32-S3R8 (8 MB PSRAM) | BLE 5.0 only",
+    ),
+    Rule(
+        "ENCODER_BUTTON",
+        # Governance trigger: revise or retire before firmware gains a real press
+        # gesture; this rule guards a currently phantom input, not future policy.
+        # The original push-button wordings, plus press/click/push of the knob or
+        # dial in either word order, plus a shaft switch given an active verb.
+        r"(encoder\s+with\s+(a\s+)?push[\s_-]*button"
+        r"|\b(press|click|push|depress)(es|ed|ing)?\s+(?:in\s+)?(?:the\s+|a\s+|your\s+)?(knob|dial)\b"
+        r"|\b(knob|dial)\s+(press|click|push)(es|ed)?\b"
+        r"|\bencoder\s+press\b"
+        r"|encoder\s+(shaft\s+)?is\s+pressable"
+        r"|\bshaft\s+switch\b[^.\n]{0,30}\b(select|selects|open|opens|confirm|confirms"
+        r"|toggle|toggles|trigger|triggers|acts|is\s+wired|is\s+read)\b)",
+        "no firmware reads a physical button; a shaft switch is physically unverified",
+        probe="| **Press the knob** | Open zone picker |",
+        antiprobe="| **Tap the zone name** | Open zone picker |",
+        # A sentence that says the mechanism is unconfirmed, or that the firmware
+        # reads no button, is the corrected wording -- not a relapse.
+        unless=r"(unconfirmed|unverified|reads\s+no\s|no\s+button\s+is\s+read|superseded)",
+        probe_exempt="Whether the encoder shaft is pressable at all is unconfirmed on the owned unit",
+    ),
+    Rule(
+        "TOUCH_VARIANT",
+        # A variant-suffixed part number is itself the assertion, so the bare form
+        # is guarded; "CST816" with no suffix stays free, because the family name
+        # is the corrected wording.
+        r"\bcst816\s*[dst]\b",
+        "the fitted touch variant is unverified; the vendor declares the CST816 family, so say "
+        "CST816 family unless the sentence is explicitly about a datasheet, marking or variant",
+        probe="Implementation: CST816D via I2C, integrated with LVGL",
+        antiprobe="Implementation: CST816-family part via I2C, integrated with LVGL",
+        # Datasheet, marking and variant discussion is legitimate: the vendor
+        # really does link a CST816D datasheet, and the open question is named in
+        # the canonical record's physical-inspection list.
+        unless=r"(datasheet|marking|variant|family|unverified|superseded|cst816 vs)",
+        probe_exempt="The datasheet Waveshare links describes the CST816D touch controller registers",
+    ),
+)
+
+
+# --------------------------------------------------------------------------- #
+# text normalisation
+# --------------------------------------------------------------------------- #
+
+# A candidate fence line: up to three spaces of indent, then a run of at least
+# three backticks or tildes, then the info string (opener) or trailing text
+# (closer). Whether it opens, closes or is merely content is decided by `Fence`,
+# because a `^\s{0,3}(```|~~~)` toggle let tildes close backticks and let a short
+# run close a long one -- and either way the rest of the file went unscanned.
+_FENCE_LINE = re.compile(r"^ {0,3}(?P<run>`{3,}|~{3,})(?P<info>.*)$")
+_INLINE_CODE = re.compile(r"`([^`]*)`")
+_LINK_TARGET = re.compile(r"\]\([^)]*\)")
+_AUTOLINK = re.compile(r"<[^>\s]*>")
+_HTML_COMMENT_OPEN = re.compile(r"<!--")
+_HTML_COMMENT_CLOSE = re.compile(r"-->")
+_HEADING = re.compile(r"^(#{1,6})\s")
+
+# A Markdown link whose *label* is a filename is a cross-reference, not a claim:
+# `[cst816d.md](cst816d.md)` names a document, it does not assert a fitted part.
+# The link target is already stripped; this strips the label in that one shape.
+_LINK_LABEL_FILE = re.compile(
+    r"\[\s*[\w./-]+\.(?:c|h|cpp|hpp|py|sh|md|ya?ml|json|txt|pdf|zip|bin|htm|html)\s*\]"
+)
+
+# A backtick span counts as quoted source -- and so as something other than an
+# assertion -- only when it carries a positive code signal. `esp_lcd_sh8601`,
+# `0x36`, `common/ui.c:389` and `board.md` are code. `AMOLED`, `SH8601`,
+# `16.7 M` and `ESP32-S3-WROOM-1` are product claims wearing backticks: their
+# contents stay in the prose stream so the rules still see them.
+_CODE_SIGNAL = re.compile(
+    r"(_"
+    r"|\(\)"
+    r"|->|::"
+    r"|[{};=]"
+    r"|^0x[0-9A-Fa-f]"
+    r"|/"
+    r"|\.(?:c|h|cpp|hpp|py|sh|md|ya?ml|json|txt|pdf|zip|bin|htm|html)\b)"
+)
+
+# One or more rule ids, comma-separated: a single line can legitimately trip more
+# than one rule (a product whose name contains the panel technology trips both),
+# and stacking two markers is not allowed. Every id listed must actually be
+# suppressed, so the list cannot be padded.
+_ALLOW_NEXT = re.compile(
+    r"^\s*<!--\s*" + re.escape(ALLOW_NEXT_NAME) + r":\s*"
+    r"(?P<rules>[A-Z][A-Z0-9_]*(?:\s*,\s*[A-Z][A-Z0-9_]*)*)\s+"
+    r"target=\"(?P<target>[^\"]+)\"\s+"
+    r"reason=\"(?P<reason>[^\"]+)\"\s*-->\s*$"
+)
+
+# Both markers only count inside an HTML comment, which is the only form that
+# could ever have silenced the guard. Prose *about* the markers -- this file's own
+# documentation, and the decision record's explanation of them -- is ordinary
+# text and must not be reported.
+_RETIRED_MARKER_USE = re.compile(r"<!--[^\n]*" + re.escape(RETIRED_MARKER))
+_ALLOW_NEXT_USE = re.compile(r"<!--[^\n]*" + re.escape(ALLOW_NEXT_NAME))
+
+
+def _despan(match):
+    body = match.group(1)
+    return " " if _CODE_SIGNAL.search(body) else " %s " % body
+
+
+def normalise(line):
+    """Strip code spans that are really code, link targets and autolinks."""
+    line = _INLINE_CODE.sub(_despan, line)
+    # Targets first, then filename labels: stripping the label would otherwise
+    # destroy the `](` that identifies the target.
+    line = _LINK_TARGET.sub("](-)", line)
+    line = _LINK_LABEL_FILE.sub("[-]", line)
+    line = _AUTOLINK.sub(" ", line)
+    return line
+
+
+UNTERMINATED_FENCE = "unterminated code fence"
+UNTERMINATED_COMMENT = "unterminated HTML comment"
+
+
+class Fence:
+    """CommonMark-shaped fenced-code tracking.
+
+    A fence closes only on the *same* character, with a run *at least as long* as
+    the opener, and with nothing but whitespace after it.  The first cut of this
+    checker toggled a boolean on any ``^\\s{0,3}(```|~~~)`` line, so a backtick
+    fence could be "closed" by tildes and a three-backtick line could "close" a
+    four-backtick opener.  Either mistake leaves the tracker's idea of the file out
+    of step with Markdown's, and the practical effect is the same in both
+    directions: a stretch of real prose is treated as code and never scanned.
+
+    Valid Markdown behaviour is preserved: an opener may carry an info string, a
+    longer closer is accepted, tilde fences may contain backtick fences and vice
+    versa, and a ```` ```code``` ```` line -- three backticks whose info string
+    itself contains a backtick -- is inline code, not a fence.
+
+    ``lineno`` is the line of an opener that is still open, so an unterminated
+    fence can be reported against the line that opened it.
+    """
+
+    __slots__ = ("char", "length", "lineno")
+
+    def __init__(self):
+        self.char = None
+        self.length = 0
+        self.lineno = 0
+
+    @property
+    def is_open(self):
+        return self.char is not None
+
+    def feed(self, lineno, raw):
+        """Consume one line; return True when it is fence syntax, not prose."""
+        match = _FENCE_LINE.match(raw)
+        if match is None:
+            return False
+        run = match.group("run")
+        info = match.group("info")
+        if self.char is None:
+            if run[0] == "`" and "`" in info:
+                # Not a fence at all: a backtick fence's info string may not
+                # contain a backtick, so this is an inline code span.
+                return False
+            self.char = run[0]
+            self.length = len(run)
+            self.lineno = lineno
+            return True
+        if run[0] == self.char and len(run) >= self.length and not info.strip():
+            self.char = None
+            self.length = 0
+            self.lineno = 0
+            return True
+        # Same shape, wrong character or too short, or carrying trailing text:
+        # Markdown treats this as content of the open fence, and so do we. The
+        # opener stays open, so if nothing ever closes it the caller reports it.
+        return False
+
+
+class Allowance:
+    __slots__ = ("lineno", "rules", "target", "reason", "covers", "problem", "used")
+
+    def __init__(self, lineno, rules, target, reason):
+        self.lineno = lineno
+        self.rules = rules
+        self.target = target
+        self.reason = reason
+        self.covers = None
+        self.problem = None
+        self.used = set()
+
+
+def analyse(text):
+    """Split a document into prose records, allowances and retired markers.
+
+    Returns ``(records, allowances, retired, malformed, defects)`` where
+    ``records`` is a list of ``(lineno, prose, section)`` triples.  ``section`` is
+    the nearest enclosing ``##`` heading (``###`` and deeper inherit it, ``#``
+    resets it), so a section allowance covers a section and not a whole file.
+
+    ``defects`` holds ``(lineno, message)`` pairs for structural states in which
+    the scan could not see the whole document: a code fence or an HTML comment
+    that is opened and never closed.  Both hide every following line, so they are
+    surfaced as structure failures rather than silently absorbing the tail.
+    """
+    records = []
+    allowances = []
+    retired = []
+    malformed = []
+    defects = []
+
+    known_rules = {rule.id for rule in RULES}
+    section = None
+    fence = Fence()
+    in_comment = False
+    comment_lineno = 0
+    pending = None
+
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        stripped = raw.strip()
+
+        # Fence syntax is only fence syntax outside a comment: a `<!--` that is
+        # still open owns every following line until it closes.
+        if not in_comment:
+            if fence.feed(lineno, raw):
+                if pending is not None:
+                    pending.problem = "allowance is followed by a code fence, not by prose"
+                    pending = None
+                continue
+            if fence.is_open:
+                continue
+
+            if _RETIRED_MARKER_USE.search(raw):
+                retired.append(lineno)
+            if _ALLOW_NEXT_USE.search(raw):
+                match = _ALLOW_NEXT.search(raw)
+                if not match:
+                    malformed.append(
+                        (
+                            lineno,
+                            'malformed allowance; the exact form is '
+                            '<!-- %s: RULE_ID target="..." reason="..." -->' % ALLOW_NEXT_NAME,
+                        )
+                    )
+                else:
+                    rules = tuple(
+                        part.strip() for part in match.group("rules").split(",") if part.strip()
+                    )
+                    allowance = Allowance(
+                        lineno,
+                        rules,
+                        match.group("target").strip(),
+                        match.group("reason").strip(),
+                    )
+                    unknown = [r for r in rules if r not in known_rules]
+                    if unknown:
+                        allowance.problem = "allowance names unknown rule(s) %s" % ", ".join(
+                            repr(r) for r in unknown
+                        )
+                    elif len(set(rules)) != len(rules):
+                        allowance.problem = "allowance repeats a rule id"
+                    elif SHIPPING_TARGET.lower() in allowance.target.lower():
+                        allowance.problem = (
+                            "allowance names the shipping target %r; this escape exists only for "
+                            "truthful facts about other boards" % allowance.target
+                        )
+                    elif len(allowance.reason) < MIN_REASON_CHARS:
+                        allowance.problem = (
+                            "allowance reason is shorter than %d characters" % MIN_REASON_CHARS
+                        )
+                    allowances.append(allowance)
+                    if pending is not None:
+                        pending.problem = (
+                            "allowances cannot be stacked; each covers exactly one prose line"
+                        )
+                    pending = allowance if allowance.problem is None else None
+                    continue
+
+        line = raw
+        if in_comment:
+            end = _HTML_COMMENT_CLOSE.search(line)
+            if not end:
+                continue
+            line = line[end.end():]
+            in_comment = False
+        while True:
+            start = _HTML_COMMENT_OPEN.search(line)
+            if not start:
+                break
+            end = _HTML_COMMENT_CLOSE.search(line, start.end())
+            if not end:
+                line = line[: start.start()]
+                in_comment = True
+                comment_lineno = lineno
+                break
+            line = line[: start.start()] + " " + line[end.end():]
+
+        # Read the heading from the comment-stripped text, never from `stripped`.
+        # `section` is what grants a `SECTION_ALLOWANCES` exemption, so a heading
+        # that only exists inside an HTML comment must neither open an allowed
+        # section nor close one -- it is not visible prose.
+        visible = line.strip()
+        heading = _HEADING.match(visible)
+        if heading:
+            depth = len(heading.group(1))
+            if depth == 1:
+                section = None
+            elif depth == 2:
+                section = visible
+
+        prose = normalise(line)
+        if not prose.strip():
+            if pending is not None and stripped:
+                pending.problem = "allowance is not immediately followed by a prose line"
+                pending = None
+            continue
+
+        records.append((lineno, prose, section))
+        if pending is not None:
+            if pending.target.lower() not in prose.lower():
+                pending.problem = (
+                    "allowance declares target %r but the line it covers does not mention it"
+                    % pending.target
+                )
+            else:
+                pending.covers = lineno
+            pending = None
+
+    if pending is not None:
+        pending.problem = "allowance has no following prose line to cover"
+
+    # Anything still open at end of file swallowed the rest of the document. Say
+    # so: a scan that could not read the tail must not be able to report OK.
+    if in_comment:
+        defects.append(
+            (
+                comment_lineno,
+                "%s opened here and never closed; every following line was hidden "
+                "from the scan" % UNTERMINATED_COMMENT,
+            )
+        )
+    if fence.is_open:
+        defects.append(
+            (
+                fence.lineno,
+                "%s opened here with %d '%s' and never closed by a run of at least that "
+                "many of the same character on a line of its own; every following line was "
+                "treated as code" % (UNTERMINATED_FENCE, fence.length, fence.char),
+            )
+        )
+
+    return records, allowances, retired, malformed, defects
+
+
+def rule_hits(records, allowed_sections=(), suppressed=None):
+    """Yield ``(lineno, rule, match)`` for every live contradiction in records.
+
+    A rule-level ``unless`` suppressor stops a hit from being a violation; it does
+    not make the hit invisible.  When ``suppressed`` is a list, every excused hit
+    is appended to it as a dict carrying the rule id, the line, the matched text
+    and the suppressor text that excused it, so a suppression can be counted and
+    read in review instead of living only in this file's regexes.  Only live
+    contradictions are *yielded*, so callers that ask "does this section still
+    restate something guarded?" are unaffected.
+    """
+    for lineno, prose, section in records:
+        if section in allowed_sections:
+            continue
+        for rule in RULES:
+            match = rule.pattern.search(prose)
+            if not match:
+                continue
+            if rule.unless is not None:
+                excuse = rule.unless.search(prose)
+                if excuse is not None:
+                    if suppressed is not None:
+                        suppressed.append(
+                            {
+                                "rule": rule.id,
+                                "line": lineno,
+                                "match": match.group(0).strip(),
+                                "suppressor": excuse.group(0).strip(),
+                            }
+                        )
+                    continue
+            yield lineno, rule, match
+
+
+# --------------------------------------------------------------------------- #
+# discovery
+# --------------------------------------------------------------------------- #
+
+
+def _skipped_relpath(root, dirpath):
+    rel = os.path.relpath(dirpath, root).replace(os.sep, "/")
+    return any(rel == skip or rel.startswith(skip + "/") for skip in SKIP_RELPATHS)
+
+
+def find_markdown(root):
+    found = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        # Exact-name exclusion only. No dot-directory rule: see SKIP_DIRS.
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+        if _skipped_relpath(root, dirpath):
+            dirnames[:] = []
+            continue
+        for name in sorted(filenames):
+            if not name.lower().endswith(".md"):
+                continue
+            abs_path = os.path.join(dirpath, name)
+            rel = os.path.relpath(abs_path, root).replace(os.sep, "/")
+            if rel in SKIP_FILES:
+                continue
+            found.append(rel)
+    return sorted(found)
+
+
+def read(root, rel):
+    try:
+        with open(os.path.join(root, rel), encoding="utf-8", errors="replace") as handle:
+            return handle.read()
+    except OSError:
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# checks
+# --------------------------------------------------------------------------- #
+
+
+def self_check():
+    """Prove the rule table and the exemption tables are live."""
+    failures = []
+    if not RULES:
+        failures.append("rule table is empty")
+    seen = set()
+    for rule in RULES:
+        if rule.id in seen:
+            failures.append("%s: duplicate rule id" % rule.id)
+        seen.add(rule.id)
+        if not rule.probe or not rule.antiprobe:
+            failures.append("%s: missing probe or antiprobe" % rule.id)
+            continue
+        if not rule.pattern.search(rule.probe):
+            failures.append("%s: probe does not match its own pattern" % rule.id)
+        if rule.pattern.search(rule.antiprobe):
+            failures.append("%s: antiprobe matches its own pattern" % rule.id)
+        # A probe stripped of code spans must still match, otherwise the rule
+        # could never fire on a real document.
+        if not rule.pattern.search(normalise(rule.probe)):
+            failures.append("%s: probe does not survive prose normalisation" % rule.id)
+        if rule.unless is None:
+            if rule.probe_exempt:
+                failures.append("%s: has probe_exempt but no unless pattern" % rule.id)
+        else:
+            if not rule.probe_exempt:
+                failures.append("%s: has an unless pattern but no probe_exempt" % rule.id)
+            else:
+                if not rule.pattern.search(rule.probe_exempt):
+                    failures.append("%s: probe_exempt does not match the rule pattern" % rule.id)
+                if not rule.unless.search(rule.probe_exempt):
+                    failures.append("%s: unless pattern does not suppress probe_exempt" % rule.id)
+            if rule.unless.search(rule.probe):
+                failures.append("%s: unless pattern also suppresses the rule's own probe" % rule.id)
+
+    # Suppression observability is asserted, not merely documented. Each rule's own
+    # `probe_exempt` is a hit its suppressor swallows, so replaying it through the
+    # scanner must produce no violation for that rule *and* exactly one recorded
+    # suppression carrying the evidence. If the recording is narrowed or removed,
+    # this fails instead of quietly shrinking what review can see.
+    suppressing = [rule for rule in RULES if rule.unless is not None]
+    if not suppressing:
+        failures.append("no rule carries a suppressor, so suppression reporting is unproven")
+    for rule in suppressing:
+        if not rule.probe_exempt:
+            continue  # already reported above
+        recorded = []
+        replay = [(1, normalise(rule.probe_exempt), None)]
+        if any(hit[1].id == rule.id for hit in rule_hits(replay, (), recorded)):
+            failures.append("%s: probe_exempt is still reported as a violation" % rule.id)
+        mine = [entry for entry in recorded if entry.get("rule") == rule.id]
+        if not mine:
+            failures.append(
+                "%s: a suppressed hit is not recorded; suppressions must stay observable" % rule.id
+            )
+            continue
+        if not mine[0].get("suppressor"):
+            failures.append("%s: recorded suppression carries no suppressor evidence" % rule.id)
+        if not mine[0].get("match") or not mine[0].get("line"):
+            failures.append("%s: recorded suppression carries no matched text or line" % rule.id)
+
+    if not REQUIRE_CANONICAL_LINK:
+        failures.append("canonical-link list is empty")
+    if not CANONICAL_SECTIONS or not CANONICAL_CLASSES or not CANONICAL_VALUES:
+        failures.append("canonical structure expectations are empty")
+
+    # Current-fact sections are never exemptible. An empty list here would make the
+    # loop below vacuous, so it is checked first.
+    if not CANONICAL_CURRENT_FACT_SECTIONS:
+        failures.append("no canonical current-fact sections are declared")
+    for section in CANONICAL_CURRENT_FACT_SECTIONS:
+        if section not in CANONICAL_SECTIONS:
+            failures.append("current-fact section %r is not a declared canonical section" % section)
+        if section in SECTION_ALLOWANCES.get(CANONICAL, ()):
+            failures.append("current-fact section %r must never carry a section allowance" % section)
+
+    known_rules = {rule.id for rule in RULES}
+    for rel, sections in SECTION_ALLOWANCES.items():
+        if not sections:
+            failures.append("%s: empty section allowance" % rel)
+        for section in sections:
+            if section not in ALLOWED_SECTION_WHITELIST:
+                failures.append(
+                    "%s: %r is not in the historical-section whitelist" % (rel, section)
+                )
+        if rel in SKIP_FILES or any(rel.startswith(skip + "/") for skip in SKIP_RELPATHS):
+            failures.append("%s: has a section allowance but is not scanned at all" % rel)
+
+    # The documented scope and the real scope must agree. An earlier cut excluded
+    # every dot-directory while claiming a repo-wide scan; that is the bug this
+    # assertion exists to prevent from returning.
+    if not MUST_SCAN_DIRS:
+        failures.append("no must-scan directories are declared")
+    for name in MUST_SCAN_DIRS:
+        if name in SKIP_DIRS:
+            failures.append("%s must stay scannable but appears in SKIP_DIRS" % name)
+    for name in SKIP_DIRS:
+        if "/" in name or os.sep in name:
+            failures.append("%r: directory skips are by bare name, not by path" % name)
+
+    for rel in SKIP_FILES:
+        if "/" in rel:
+            failures.append("%s: file skips are root-level only, to keep them narrow" % rel)
+        if rel in (CANONICAL, ADR, DOCS_INDEX):
+            failures.append("%s: a required document may not be skipped" % rel)
+
+    # The source-anchor table is an assertion about files outside the Markdown scan,
+    # so its own shape is checked here: an empty table, a duplicate id, an absolute
+    # or escaping path, an empty token, a bare token that cannot state a
+    # relationship, or an anchor that names no claim would all make a freshness
+    # finding unactionable or vacuous.
+    if not SOURCE_ANCHORS:
+        failures.append("source-anchor table is empty")
+    seen_anchors = set()
+    for anchor in SOURCE_ANCHORS:
+        if anchor.id in seen_anchors:
+            failures.append("%s: duplicate source-anchor id" % anchor.id)
+        seen_anchors.add(anchor.id)
+        if not anchor.path:
+            failures.append("%s: source anchor has no path" % anchor.id)
+        elif anchor.path.startswith("/") or ".." in anchor.path.split("/"):
+            failures.append(
+                "%s: source-anchor path %r must be repo-relative and must not escape the root"
+                % (anchor.id, anchor.path)
+            )
+        if not anchor.tokens:
+            failures.append("%s: source anchor asserts no tokens, so it can never fail" % anchor.id)
+        seen_tokens = set()
+        for token in anchor.tokens:
+            collapsed = " ".join(token.split())
+            if not collapsed:
+                failures.append("%s: source anchor carries an empty expected token" % anchor.id)
+                continue
+            if collapsed in seen_tokens:
+                failures.append(
+                    "%s: source anchor repeats the expected token %r, which adds no assertion"
+                    % (anchor.id, token)
+                )
+            seen_tokens.add(collapsed)
+            # A bare identifier or bare literal is the split-token shape: two of
+            # them can both be present while the relationship between them is gone.
+            # See the module docstring, "Tokens must carry their own relationship".
+            if _BARE_TOKEN.match(collapsed):
+                failures.append(
+                    "%s: expected token %r is a bare identifier or literal, so it cannot state "
+                    "the relationship the row cites and would be satisfied by a file in which "
+                    "that relationship has drifted apart; pin the whole line or block instead"
+                    % (anchor.id, token)
+                )
+        if not anchor.claim or not anchor.claim.strip():
+            failures.append(
+                "%s: source anchor names no claim, so a freshness finding could not say what "
+                "to re-derive" % anchor.id
+            )
+
+    if RETIRED_MARKER == ALLOW_NEXT_NAME:
+        failures.append("the retired marker and the live marker must differ")
+    if not known_rules:
+        failures.append("no rule ids available for allowance validation")
+
+    return failures
+
+
+def scan_violations(root, files):
+    """Scan every file.
+
+    Returns ``(violations, marker_problems, structure_problems, suppressions)``:
+
+    *   ``violations`` -- live guarded contradictions.
+    *   ``marker_problems`` -- abuse of the allowance markers, which is an attempt
+        to hide a contradiction and so ranks with one.
+    *   ``structure_problems`` -- pre-formatted strings for states in which the
+        scan could not read a whole document (unterminated comment or fence) or in
+        which an allowance has stopped suppressing anything.
+    *   ``suppressions`` -- every hit a rule's ``unless`` clause excused, so the
+        excuse is observable rather than implicit.
+    """
+    violations = []
+    marker_problems = []
+    structure_problems = []
+    suppressions = []
+
+    for rel in files:
+        text = read(root, rel)
+        if text is None:
+            continue
+        records, allowances, retired, malformed, defects = analyse(text)
+        allowed_sections = SECTION_ALLOWANCES.get(rel, ())
+
+        for lineno, detail in defects:
+            structure_problems.append("%s:%d: %s" % (rel, lineno, detail))
+
+        for lineno in retired:
+            marker_problems.append(
+                {
+                    "file": rel,
+                    "line": lineno,
+                    "message": "carries the retired %s marker; file-level exemptions were "
+                    "replaced by section allowances and %s" % (RETIRED_MARKER, ALLOW_NEXT_NAME),
+                }
+            )
+        for lineno, detail in malformed:
+            marker_problems.append({"file": rel, "line": lineno, "message": detail})
+        for allowance in allowances:
+            if allowance.problem:
+                marker_problems.append(
+                    {"file": rel, "line": allowance.lineno, "message": allowance.problem}
+                )
+        live = [a for a in allowances if a.problem is None and a.covers is not None]
+
+        excused = []
+        for lineno, rule, match in rule_hits(records, allowed_sections, excused):
+            covering = None
+            for allowance in live:
+                if allowance.covers == lineno and rule.id in allowance.rules:
+                    covering = allowance
+                    break
+            if covering is not None:
+                covering.used.add(rule.id)
+                continue
+            violations.append(
+                {
+                    "rule": rule.id,
+                    "file": rel,
+                    "line": lineno,
+                    "match": match.group(0).strip(),
+                    "message": rule.message,
+                }
+            )
+
+        for hit in excused:
+            entry = {"file": rel}
+            entry.update(hit)
+            suppressions.append(entry)
+
+        for allowance in live:
+            idle = [r for r in allowance.rules if r not in allowance.used]
+            if idle:
+                structure_problems.append(
+                    "%s:%d: allowance lists %s but suppresses nothing for %s; narrow or delete it"
+                    % (rel, allowance.lineno, ",".join(allowance.rules), ",".join(idle))
+                )
+
+    return violations, marker_problems, structure_problems, suppressions
+
+
+def check_source_anchors(root):
+    """Verify the source text behind the canonical record's repository-observed rows.
+
+    Returns ``(failures, inventory)``.  ``failures`` are pre-formatted ``STRUCTURE``
+    strings: a cited file that is absent, or a cited file that no longer carries an
+    expected literal token.  ``inventory`` is every anchor with its status, so the
+    JSON report shows what was checked and not only what failed.
+
+    The finding wording is deliberate.  A present token proves the citation is
+    fresh, not that the claim is physically true; a missing token proves the
+    citation is stale, not that the claim is false.  The remedy in both directions
+    is to re-read the source and re-derive the row.  Both findings carry
+    ``ANCHOR_CAVEAT``, because the failure a reader will assume is covered -- a
+    cited line *number* going stale -- is the one this layer cannot see.
+    """
+    failures = []
+    inventory = []
+
+    for anchor in SOURCE_ANCHORS:
+        entry = {
+            "id": anchor.id,
+            "path": anchor.path,
+            "tokens": list(anchor.tokens),
+            "claim": anchor.claim,
+        }
+        text = read(root, anchor.path)
+        if text is None:
+            failures.append(
+                "source anchor %s: cited file %s is absent, so the canonical record's claim "
+                "that %s can no longer be checked against the source it was read from; "
+                "re-derive the row or update the anchor (absence of the file is not evidence "
+                "the claim is false; %s)" % (anchor.id, anchor.path, anchor.claim, ANCHOR_CAVEAT)
+            )
+            entry["status"] = "missing-file"
+            entry["missing"] = list(anchor.tokens)
+            inventory.append(entry)
+            continue
+
+        missing = [
+            token
+            for token, pattern in zip(anchor.tokens, anchor.patterns)
+            if pattern is None or not pattern.search(text)
+        ]
+        if missing:
+            failures.append(
+                "source anchor %s: %s no longer contains %s, so the canonical record's claim "
+                "that %s cites text that has moved or changed; re-read the source and "
+                "re-derive the row (a missing token means the citation is stale, not that "
+                "the claim is false; %s)"
+                % (
+                    anchor.id,
+                    anchor.path,
+                    ", ".join(repr(token) for token in missing),
+                    anchor.claim,
+                    ANCHOR_CAVEAT,
+                )
+            )
+            entry["status"] = "missing-token"
+            entry["missing"] = missing
+        else:
+            entry["status"] = "ok"
+            entry["missing"] = []
+        inventory.append(entry)
+
+    return failures, inventory
+
+
+def _section_records(records, heading):
+    return [rec for rec in records if rec[2] == heading]
+
+
+def check_structure(root, files):
+    """Canonical record integrity, links and allowance hygiene."""
+    failures = []
+    missing = []
+
+    if not files:
+        missing.append("no Markdown files found under %s" % root)
+
+    canonical = read(root, CANONICAL)
+    if canonical is None:
+        missing.append("canonical record absent: %s" % CANONICAL)
+    adr = read(root, ADR)
+    if adr is None:
+        missing.append("decision record absent: %s" % ADR)
+
+    if canonical is not None:
+        cursor = -1
+        for section in CANONICAL_SECTIONS:
+            found = canonical.find(section, cursor + 1)
+            if found < 0:
+                if section in canonical:
+                    failures.append(
+                        "%s: required section %r is out of order" % (CANONICAL, section)
+                    )
+                else:
+                    failures.append("%s: missing required section %r" % (CANONICAL, section))
+            else:
+                cursor = found
+        for klass in CANONICAL_CLASSES:
+            if klass not in canonical:
+                failures.append("%s: provenance class %r not named" % (CANONICAL, klass))
+        # A superseded value in the exempt Historical section must not satisfy
+        # the live-record sentinel.  Keep this check on the raw current-fact
+        # sections so code-like values (for example Kconfig symbols) remain
+        # visible even though normalise() removes them from prose scanning.
+        current_lines = []
+        current_section = None
+        fence = Fence()
+        for lineno, raw in enumerate(canonical.splitlines(), start=1):
+            if fence.feed(lineno, raw):
+                continue
+            heading = None if fence.is_open else _HEADING.match(raw.strip())
+            if heading is not None:
+                depth = len(heading.group(1))
+                if depth == 1:
+                    current_section = None
+                elif depth == 2:
+                    current_section = raw.strip()
+            if current_section in CANONICAL_CURRENT_FACT_SECTIONS:
+                current_lines.append(raw)
+        current_facts = "\n".join(current_lines)
+        for value in CANONICAL_VALUES:
+            if value not in current_facts:
+                failures.append("%s: corrected value %r no longer present" % (CANONICAL, value))
+        if os.path.basename(ADR) not in canonical:
+            failures.append("%s: does not link the decision record" % CANONICAL)
+
+    index = read(root, DOCS_INDEX)
+    if index is not None and os.path.basename(ADR) not in index:
+        failures.append("%s: does not link the decision record" % DOCS_INDEX)
+
+    # Section allowances must be real and must still be earning their keep: an
+    # allowance over a section that no longer restates anything is a hole.
+    for rel, sections in SECTION_ALLOWANCES.items():
+        text = read(root, rel)
+        if text is None:
+            missing.append("file with a section allowance is absent: %s" % rel)
+            continue
+        records = analyse(text)[0]
+        for section in sections:
+            headings = [rec for rec in records if rec[1].strip() == section]
+            if not headings:
+                failures.append("%s: allowed section %r is absent" % (rel, section))
+                continue
+            if len(headings) > 1:
+                failures.append("%s: allowed section %r appears more than once" % (rel, section))
+            in_section = _section_records(records, section)
+            if not any(True for _ in rule_hits(in_section)):
+                failures.append(
+                    "%s: allowed section %r restates nothing guarded; the allowance is dead "
+                    "and must be removed" % (rel, section)
+                )
+
+    canonical_name = os.path.basename(CANONICAL)
+    link_pattern = re.compile(r"\]\(([^)\s]+)")
+    for rel in REQUIRE_CANONICAL_LINK:
+        text = read(root, rel)
+        if text is None:
+            missing.append("required document absent: %s" % rel)
+            continue
+        linked = False
+        for match in link_pattern.finditer(text):
+            target = match.group(1).strip("<>").split("#", 1)[0].split("?", 1)[0]
+            if not target or "://" in target:
+                continue
+            if target.startswith("/"):
+                candidate = os.path.normpath(target.lstrip("/"))
+            else:
+                candidate = os.path.normpath(os.path.join(os.path.dirname(rel), target))
+            if candidate == CANONICAL and os.path.isfile(os.path.join(root, candidate)):
+                linked = True
+                break
+        if not linked:
+            failures.append("%s: no Markdown link to %s" % (rel, canonical_name))
+
+    return failures, missing
+
+
+# --------------------------------------------------------------------------- #
+# entry point
+# --------------------------------------------------------------------------- #
+
+
+def default_root():
+    return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def build_parser():
+    parser = argparse.ArgumentParser(
+        prog=TOOL,
+        description="Guard the canonical round-target identity record (issue #211).",
+        epilog=(
+            "This is a phrase tripwire and source-text freshness check, not semantic or "
+            "factual proof. A green result does not replace human review of identity claims; "
+            "source anchors do not validate cited line numbers, negative claims, derived "
+            "counts, or physical hardware truth."
+        ),
+    )
+    parser.add_argument("--root", default=None, help="repository root (default: parent of scripts/)")
+    parser.add_argument("--report", default=None, help="write a JSON report to this path")
+    parser.add_argument("--list-rules", action="store_true", help="print rule ids and exit 0")
+    parser.add_argument(
+        "--list-anchors",
+        action="store_true",
+        help="print 'id<TAB>path' for every source anchor and exit 0",
+    )
+    parser.add_argument(
+        "--self-check",
+        action="store_true",
+        help="verify the checker's own rules, then continue with the scan",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help=(
+            "suppress the per-hit suppression and violation lines, and the fenced-block "
+            "quoting note printed with them; the summary token and "
+            "the MISSING, SELFCHECK, MARKER-ABUSE and STRUCTURE lines are still printed"
+        ),
+    )
+    return parser
+
+
+def main(argv):
+    parser = build_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        # argparse uses SystemExit(0) for --help. That is successful usage, not the
+        # malformed-invocation contract below; preserve the help text it already
+        # printed and return success to the caller.
+        if exc.code == 0:
+            return EXIT_OK
+        print("%s: bad invocation" % TOKEN_USAGE)
+        return EXIT_USAGE
+
+    for name in ("root", "report"):
+        value = getattr(args, name)
+        if value is not None and not value.strip():
+            print("%s: --%s given an empty value" % (TOKEN_USAGE, name))
+            return EXIT_USAGE
+
+    if args.list_rules:
+        for rule in RULES:
+            print(rule.id)
+        return EXIT_OK
+
+    # The fixture suite reads this to build self-contained temporary roots that
+    # carry exactly the cited source files and nothing else.
+    if args.list_anchors:
+        for anchor in SOURCE_ANCHORS:
+            print("%s\t%s" % (anchor.id, anchor.path))
+        return EXIT_OK
+
+    root = os.path.abspath(args.root) if args.root else default_root()
+    if not os.path.isdir(root):
+        print("%s: root is not a directory: %s" % (TOKEN_MISSING, root))
+        return EXIT_MISSING
+
+    selfcheck_failures = self_check() if args.self_check else []
+
+    files = find_markdown(root)
+    violations, marker_problems, scan_structure, suppressions = scan_violations(root, files)
+    structure_failures, missing = check_structure(root, files)
+    anchor_failures, anchors = check_source_anchors(root)
+    structure_failures = structure_failures + scan_structure + anchor_failures
+
+    for entry in missing:
+        print("%s: %s" % (TOKEN_MISSING, entry))
+    for entry in selfcheck_failures:
+        print("%s: %s" % (TOKEN_SELFCHECK, entry))
+    for entry in marker_problems:
+        print(
+            "%s: %s:%d: %s"
+            % (TOKEN_MARKER_ABUSE, entry["file"], entry["line"], entry["message"])
+        )
+    for entry in structure_failures:
+        print("%s: %s" % (TOKEN_STRUCTURE, entry))
+    if not args.quiet:
+        # Informational, and printed before the violations so a reader sees what
+        # the guard chose *not* to report. These never affect the exit code.
+        for entry in suppressions:
+            print(
+                "%s: %s %s:%d: %r suppressed by %r"
+                % (
+                    TOKEN_SUPPRESSED,
+                    entry["rule"],
+                    entry["file"],
+                    entry["line"],
+                    entry["match"],
+                    entry["suppressor"],
+                )
+            )
+        for entry in violations:
+            print(
+                "%s: %s %s:%d: %r -- %s"
+                % (
+                    TOKEN_VIOLATION,
+                    entry["rule"],
+                    entry["file"],
+                    entry["line"],
+                    entry["match"],
+                    entry["message"],
+                )
+            )
+        # Printed once with the violation lines it annotates, not once per hit: the
+        # remedy is the same for all of them, and a paragraph repeated per finding
+        # is the kind of noise readers learn to skip. It is still part of the
+        # violation report -- same token, printed immediately after the hits -- so a
+        # reader who sees a violation sees why an indented quotation became one.
+        if violations:
+            print("%s: %s" % (TOKEN_VIOLATION, QUOTING_NOTE))
+
+    # Marker abuse is a contradiction-class failure: it is an attempt to hide one.
+    violation_count = len(violations) + len(marker_problems)
+
+    if missing:
+        exit_code, token = EXIT_MISSING, TOKEN_MISSING
+    elif selfcheck_failures:
+        exit_code, token = EXIT_SELFCHECK, TOKEN_SELFCHECK
+    elif structure_failures:
+        exit_code, token = EXIT_STRUCTURE, TOKEN_STRUCTURE
+    elif violation_count:
+        exit_code, token = EXIT_VIOLATION, TOKEN_VIOLATION
+    else:
+        exit_code, token = EXIT_OK, TOKEN_OK
+
+    # `rules` is the size of the rule table, not a branch-coverage figure: see the
+    # module docstring. `suppressed` is informational and does not gate the exit.
+    # `anchors_fresh` is how many anchors still carry every expected token, out of
+    # the size of the anchor table; a shortfall is already counted in `structure`.
+    # It is NOT a coverage figure over the repository-observed rows -- see
+    # ANCHOR_SCOPE and the module docstring.
+    print(
+        "%s: files=%d rules=%d violations=%d structure=%d missing=%d selfcheck=%d "
+        "suppressed=%d anchors_fresh=%d/%d"
+        % (
+            token,
+            len(files),
+            len(RULES),
+            violation_count,
+            len(structure_failures),
+            len(missing),
+            len(selfcheck_failures),
+            len(suppressions),
+            sum(1 for a in anchors if a["status"] == "ok"),
+            len(anchors),
+        )
+    )
+
+    if args.report:
+        report = {
+            "tool": TOOL,
+            "version": VERSION,
+            "root": root,
+            "files_scanned": files,
+            "rules": [{"id": r.id, "message": r.message} for r in RULES],
+            # Every anchor, not only the failing ones: a reader can see which
+            # citations were checked. Failures also appear in `structure_failures`,
+            # which is what gates the exit code. `source_anchor_scope` travels with
+            # them so the count cannot be read as coverage over the R rows.
+            "source_anchors": anchors,
+            "source_anchor_scope": ANCHOR_SCOPE,
+            "violations": violations,
+            # Travels with the violations so the step summary and any other reader
+            # of the report states the indented-code consequence from the checker
+            # rather than restating it independently.
+            "quoting_note": QUOTING_NOTE,
+            "marker_abuse": marker_problems,
+            "suppressions": suppressions,
+            "structure_failures": structure_failures,
+            "missing": missing,
+            "selfcheck_failures": selfcheck_failures,
+            "token": token,
+            "exit_code": exit_code,
+        }
+        try:
+            with open(args.report, "w", encoding="utf-8") as handle:
+                json.dump(report, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+        except OSError as exc:
+            print("%s: could not write report %s: %s" % (TOKEN_USAGE, args.report, exc))
+            return EXIT_USAGE
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/fixtures/docs_identity/README.md
+++ b/scripts/fixtures/docs_identity/README.md
@@ -1,0 +1,115 @@
+# `check_docs_identity` fixtures
+
+These files deliberately contain the identity contradictions that
+[`scripts/check_docs_identity.py`](../../check_docs_identity.py) exists to reject. The checker
+skips `scripts/fixtures` for exactly that reason — see `SKIP_RELPATHS` — and
+`scripts/test_check_docs_identity.sh` asserts that the skip is real and that the same files are
+still scanned anywhere else.
+
+| File | Purpose |
+|---|---|
+| `violation_<RULE_ID>.md` | Must make rule `<RULE_ID>` fire. One per rule; the harness reads the rule list from `--list-rules`, so adding a rule without a fixture fails the suite. |
+| `clean_all.md` | Every corrected wording in one file. Must produce **zero** violations, proving the rules are specific rather than matching any mention of the subject. |
+| `code_context_exempt.md` | The guarded phrases appear only inside a fenced block, a link target, or an autolink. Must produce zero violations. |
+| `code_context_bare.md` | The same phrases in prose. Must produce violations — this is what stops the code exemption from swallowing everything. |
+| `indented_code_scanned.md` | The guarded phrases inside a **four-space indented** block. Must produce violations: indented code is CommonMark code but is scanned here as prose, so it is the one exemption a reader expects and does not get. The suite also asserts the violation output, the JSON report (`quoting_note`) and the step summary all name the remedy — fence the quotation — and that the same lines inside a fence are exempt, so the remedy is a real one. |
+| `fence_valid.md` | Well-formed fences only: an info string on the opener, a tilde fence containing a backtick fence, a four-backtick fence closed by five, and a three-space-indented fence. Guarded wordings inside them must stay exempt, so this must produce zero violations. |
+| `fence_mismatched.md` | A backtick fence "closed" by tildes, with a contradiction after it. Markdown keeps the fence open, so the checker must report an **unterminated code fence** structure failure naming the opening line — never `RK-IDENT-OK`. |
+| `fence_short_closer.md` | A four-backtick fence "closed" by three, with a contradiction after it. Same requirement: a named unterminated-fence structure failure, because a closer must be at least as long as its opener. |
+| `comment_closed.md` | One-line, multi-line and mid-line HTML comments, all properly closed, containing guarded wordings. Must produce zero violations, and the prose after the closing marker must still be scanned. |
+| `comment_unterminated.md` | An HTML comment opener with no closing marker, with a contradiction after it. Must be reported as an **unterminated HTML comment** structure failure naming the opening line — never `RK-IDENT-OK`. |
+| `suppressed_hits.md` | Truthful qualified prose that trips a rule and is then excused by that rule's `unless` clause. Must exit 0 **and** must appear in `suppressions` with file, line, rule id, matched text and the suppressor that excused it, so suppression stays observable. |
+| `code_identifiers.md` | Backtick spans that carry a code signal (underscore, call syntax, statement punctuation, hex literal, path, filename extension). Must produce zero violations. |
+| `backtick_claims.md` | Bare product, panel, controller and module claims wrapped in backticks. Must produce violations: backticks alone are not a code signal, so they no longer buy an exemption. |
+| `other_target_marked.md` | A truthful claim about a **different** board, carrying a well-formed `rk-ident-allow-next-line` allowance that lists both rules the line trips. Must produce zero violations. |
+| `other_target_unmarked.md` | The same truthful sentence with no allowance. Must produce a violation, so the escape is doing real work. |
+| `other_target_second_line.md` | A valid allowance followed by a covered line **and** an uncovered one. Must produce a violation for the second line only. |
+| `other_target_unrelated_line.md` | An allowance whose covered line never mentions the declared other target. Must be reported as marker abuse. |
+| `other_target_shipping.md` | An allowance naming the shipping target. Must be reported as marker abuse. |
+| `other_target_no_reason.md` | An allowance with a token reason. Must be reported as marker abuse. |
+| `retired_marker.md` | The retired file-level `rk-ident-allow-file` comment. Must be reported as marker abuse, and the contradiction it tried to hide must still be reported. |
+| `paraphrases.tsv` | `RULE_ID`↹sentence. Each sentence is planted alone in a throwaway tree and must be reported for that rule. None is a probe, an antiprobe, or a wording this repository ever used — this file is the checker's only evidence of recall beyond the wordings it was written from. |
+| `paraphrases_clean.tsv` | `why`↹sentence. Truthful prose that shares vocabulary with a guarded phrase. Each must produce **zero** violations, so strengthening a rule cannot quietly turn it into a topic ban. |
+| `report_all_groups.json` | A synthetic `--report` payload carrying `violations`, `marker_abuse`, `structure_failures`, `missing`, `selfcheck_failures` and `suppressions` at once. Drives the tests for [`scripts/summarize_docs_identity.py`](../../summarize_docs_identity.py); the `marker_abuse` rows are the shape that used to crash the workflow's inline renderer with a `KeyError`, and the `suppressions` rows are the informational group, which is rendered but must not count as a finding. |
+
+The paraphrase recall claim is scoped to the single-physical-line renderings in the corpus. The
+harness also plants `CONTROLLER_CLAIM`, `BACKLIGHT_DUTY`, and `ENCODER_BUTTON` phrases split
+across two lines and requires each to pass, pinning physical-line wrapping as a known blind spot
+rather than silently treating it as coverage.
+
+Wording here is written independently of the checker's own `probe`/`antiprobe` strings, so the
+suite is not merely asserting that the regexes match themselves. That independence is the whole
+value of `paraphrases.tsv`: a rule that matches only its own probe passes the per-rule fixture
+loop and still catches nothing a reviewer would write.
+
+## Two things with no fixture file here
+
+**Source anchors** are checked against the repository's *real* sources, so there is nothing to
+fixture. `SOURCE_ANCHORS` asserts that each file cited by the canonical record's
+repository-observed rows still carries its expected tokens. The harness asks the checker for the
+list (`--list-anchors`) and copies exactly those files into each throwaway root, which is what
+keeps a temporary tree self-contained without dragging in the firmware tree — add an anchor and the
+roots pick it up with no edit here.
+
+Each token is a whole line or a whole block that states the relationship the row cites, matched
+whitespace-insensitively and word-boundary guarded. Four discriminating cases pin that:
+
+| Case | Mutation | Requirement |
+|---|---|---|
+| stale token | rewrite the `CONFIG_RK_BACKLIGHT_NORMAL` duty assignment | named non-zero `STRUCTURE` finding, exactly one anchor |
+| absent file | delete `idf_app/main/idf_component.yml` | named non-zero `STRUCTURE` finding, exactly one anchor |
+| broken relationship | repoint encoder A to `GPIO_NUM_9`, leaving `GPIO_NUM_8` in a trailing comment | must still fail — a split `#define ENCODER_GPIO_A` + `GPIO_NUM_8` pair would not |
+| prefix | widen `TOUCH_ADDR 0x15` to `0x155` | must fail — a token may not be satisfied by a longer literal starting with it |
+
+Whitespace flexibility is bounded on both sides, and each bound is pinned by a case that must
+stay green or must fail:
+
+| Case | Mutation | Requirement |
+|---|---|---|
+| realignment | collapse the padding in `#define ENCODER_GPIO_A    GPIO_NUM_8` | must stay green — pinning whole lines is only reasonable if reformatting does not break them |
+| punctuation join | unwrap `SH8601_PANEL_IO_QSPI_CONFIG(` + `PIN_NUM_LCD_CS,` onto one line, **both** with and without a space after `(` | must stay green — at a punctuation boundary the gap may close entirely, so unwrapping an argument list is not a stale citation |
+| word fusion | fuse `#define PIN_NUM_BK_LIGHT` into `#definePIN_NUM_BK_LIGHT` | must fail — whitespace between two *word* lexemes stays mandatory, or two identifiers fused into one would satisfy the token |
+
+`--self-check` additionally refuses an anchor with no tokens and one whose token is a bare
+identifier or literal, since both are ways this layer rots into decoration.
+
+Three limits are asserted in the wording of the findings and in the report, not just documented:
+
+- an anchor proves a **citation is fresh**, never that a fact is true, so no finding may be worded
+  as evidence the documented claim is false;
+- an anchor **does not check the line numbers** the rows cite (`platform_display_idf.c:55` – `:61`).
+  Pure line movement leaves every one of those stale with every token still present and the guard
+  still green. The suite deliberately asserts no line numbers — doing so would make every unrelated
+  edit above a cited line a red documentation guard. Keeping the citations correct is human review,
+  tracked in [#213](https://github.com/muness/roon-knob/issues/213);
+- the anchor count is **not coverage**. The table covers a subset of the repository-observed rows.
+  Negative rows ("no physical button is read anywhere") and uniqueness rows ("the *only* emitter of
+  `UI_INPUT_MENU`") are absence claims that no token can establish; derived counts, diffs against
+  the vendor archive, and anything about the silicon are not quotable repository text. The suite
+  asserts a floor on the anchor table and the presence of specific anchors — never an equality with
+  the number of rows.
+
+**The suppression fingerprint** is a constant in `scripts/test_check_docs_identity.sh`
+(`EXPECTED_SUPPRESSION_FINGERPRINT`): one `rule|file|suppressor|count` line per distinct triple,
+sorted. Line numbers and matched prose are excluded on purpose, so a moved line or a reworded
+sentence does not churn it. What it *does* catch is one suppressor being swapped for another, which
+a scalar total could not see at an unchanged count — and, because of the trailing count, an
+*additional* suppressed hit inside a triple the baseline already lists. Without that count an
+existing baseline line is a standing licence: further sentences in the same file could take the same
+excuse from the same rule and nothing would move.
+
+Those three properties are proven against a **fixed synthetic** suppression set, not against this
+repository's live one, and the distinction matters. A control derived from the live baseline fails
+the moment the repository legitimately gains or loses a suppression, so one honest documentation edit
+would report both "the baseline moved" (true, and the intended friction) and "the fingerprint no
+longer ignores line numbers" (false, and a diagnostic aimed at the wrong thing). With synthetic rows,
+a legitimate live change fails exactly one assertion with exactly one cause.
+
+That failure is review friction, not a runtime failure of truthful prose: suppressions never change
+the checker's exit code, and a run whose only findings are suppressions is still `RK-IDENT-OK`. The
+failure message prints a diff of pinned versus actual, names the command to run, and says what to
+establish in review before updating the constant.
+
+Neither of these is wired into `scripts/ci_sanity.sh`; the guard's local route is the direct
+command named in `AGENTS.md` and `docs/dev/DEVELOPMENT.md`, and the suite proves that command works
+on a host with no ESP-IDF.

--- a/scripts/fixtures/docs_identity/backtick_claims.md
+++ b/scripts/fixtures/docs_identity/backtick_claims.md
@@ -1,0 +1,11 @@
+# Wrong claims wearing backticks
+
+Every claim below sits inside a backtick span, which used to be enough to silence the guard.
+None of these spans carries a code signal, so each one is still an assertion and must be
+reported.
+
+The panel is an `AMOLED` module. Colour capability is `16.7 million` colours.
+The display controller is the `SH8601`. The compute module is an `ESP32-S3-WROOM-1`.
+The product is the `Waveshare ESP32-S3 Touch AMOLED 1.8"` board.
+A stale note in another tree read `Display controller | SH8601` and another read
+`no backlight required`.

--- a/scripts/fixtures/docs_identity/clean_all.md
+++ b/scripts/fixtures/docs_identity/clean_all.md
@@ -1,0 +1,20 @@
+# Corrected wording, every guarded subject in one file
+
+Every sentence below discusses a guarded subject using the corrected wording. This file must
+produce **zero** violations. If a rule ever starts firing here, that rule has become a blanket
+ban on mentioning the topic rather than a guard against the wrong assertion.
+
+- The target is the Waveshare ESP32-S3-Knob-Touch-LCD-1.8, and no other product.
+- The panel is a 1.8 inch round IPS LCD at 360×360 over Quad SPI.
+- Waveshare declares 262K colours, 600 cd/m² brightness, and a 1200:1 contrast ratio.
+- Brightness is a PWM backlight on GPIO 47, driven through LEDC with 8-bit duty resolution.
+- The initial duty is CONFIG_RK_BACKLIGHT_NORMAL, whose Kconfig default is 100 of 255, about
+  39 per cent; the dim level is 25 of 255, about 10 per cent.
+- The vendor-declared panel driver IC is ST77916; the software component the firmware binds
+  through is esp_lcd_sh8601, which is a different kind of thing entirely.
+- Vendor-declared part numbers are ESP32-S3R8 for the primary SoC and ESP32-U4WDH for the
+  secondary; the module package is not claimed here.
+- Touch is a CST816-family part read as raw registers over I2C at address 0x15. The datasheet
+  Waveshare links is the CST816D one, and the fitted marking is unverified.
+- Turning the knob changes volume. Tapping the zone name opens the zone picker. A long press on
+  the zone name opens settings. No physical button is read by the firmware.

--- a/scripts/fixtures/docs_identity/code_context_bare.md
+++ b/scripts/fixtures/docs_identity/code_context_bare.md
@@ -1,0 +1,10 @@
+# The same phrases as prose
+
+Identical claims to `code_context_exempt.md`, but asserted in prose rather than quoted as
+source. This file must produce violations — otherwise the code exemption has swallowed the
+whole guard.
+
+Panel: 360x360 round AMOLED, 16.7 million colors, no backlight, on an ESP32-S3-WROOM-1.
+The display controller is an SH8601 over QSPI. Press the knob to open the zone picker.
+The product is the Waveshare ESP32-S3 Touch AMOLED 1.8 inch board.
+The backlight starts at 50% duty. The touch part is a CST816S touch controller.

--- a/scripts/fixtures/docs_identity/code_context_exempt.md
+++ b/scripts/fixtures/docs_identity/code_context_exempt.md
@@ -1,0 +1,22 @@
+# Code context is exempt
+
+Guarded phrases below appear only inside a fenced block, so they are quotations of source, not
+assertions about the board. This file must produce zero violations.
+
+```c
+// Swap bytes for big-endian QSPI display (SH8601 expects big-endian RGB565)
+// Panel: 360x360 round AMOLED, 16.7 million colors, no backlight, ESP32-S3-WROOM-1
+// Press the knob to open the zone picker
+// Backlight starts at 50% duty
+static const sh8601_lcd_init_cmd_t lcd_init_cmds[] = {
+    {0x36, (uint8_t[]){0x00}, 1, 0},
+};
+```
+
+A link whose *target* contains a guarded word is also not an assertion, because only the link
+text is prose: [a different Waveshare product](https://www.waveshare.com/esp32-s3-touch-amoled-1.8.htm)
+and the bare autolink <https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.8>.
+
+Backtick spans are covered separately: `code_identifiers.md` proves that spans carrying a code
+signal stay exempt, and `backtick_claims.md` proves that a bare product claim in backticks does
+not.

--- a/scripts/fixtures/docs_identity/code_identifiers.md
+++ b/scripts/fixtures/docs_identity/code_identifiers.md
@@ -1,0 +1,14 @@
+# Real code identifiers stay exempt
+
+Every span below carries a code signal — an underscore, call syntax, statement punctuation, a
+hex literal, a path, or a filename extension — so it is quoted source rather than an assertion.
+This file must produce zero violations.
+
+The panel is created by `esp_lcd_new_panel_sh8601()`, declared in `esp_lcd_sh8601.h`, and the
+init array has type `sh8601_lcd_init_cmd_t` with entries like `{0x36, {0x00}, 1, 0}`.
+Touch lives at `0x15` and is read by `tpGetCoordinates()` in
+`idf_app/components/lcd_touch_bsp/lcd_touch_bsp.c`.
+Brightness comes from `CONFIG_RK_BACKLIGHT_NORMAL`, configured with `.duty = CONFIG_RK_BACKLIGHT_NORMAL`.
+The component default array is `vendor_specific_init_default[]`; the pixel format follows
+`panel_dev_config.bits_per_pixel`. Provenance is in `board.md`, enforced by
+`scripts/check_docs_identity.py`.

--- a/scripts/fixtures/docs_identity/comment_closed.md
+++ b/scripts/fixtures/docs_identity/comment_closed.md
@@ -1,0 +1,18 @@
+# A closed HTML comment is still an exemption
+
+Commenting a superseded sentence out is a legitimate edit, and the checker reads prose rather
+than comments. Both a one-line comment and a comment that spans lines must stay exempt, and the
+prose after the closing marker must still be scanned. This file must produce zero violations.
+
+<!-- The panel is a round AMOLED with 16.7 million colours and no backlight. -->
+
+<!--
+An earlier draft of this page said the display controller IC is the SH8601 and that the
+ESP32-S3-WROOM-1 module carries it. Press the knob to open the zone picker. Backlight starts
+at 50 % duty.
+-->
+
+Text and <!-- a guarded AMOLED aside --> more text on one line is exempt in the middle only.
+
+The panel is a 360x360 round IPS LCD; the vendor declares an ST77916 driver IC and 262K
+colours, and the firmware drives an LEDC PWM backlight on GPIO 47.

--- a/scripts/fixtures/docs_identity/comment_unterminated.md
+++ b/scripts/fixtures/docs_identity/comment_unterminated.md
@@ -1,0 +1,11 @@
+# An unterminated HTML comment hides the rest of the file
+
+The comment opener below is never closed. Everything after it is invisible to the scan,
+including the contradiction on the last line, so this file must be reported as a structure
+failure naming the opening line -- it must never be able to produce RK-IDENT-OK.
+
+<!-- an opener with no closing marker anywhere in this file
+
+The panel is a 360x360 round IPS LCD.
+
+The display is a round AMOLED with 16.7 million colours and no backlight control.

--- a/scripts/fixtures/docs_identity/fence_mismatched.md
+++ b/scripts/fixtures/docs_identity/fence_mismatched.md
@@ -1,0 +1,14 @@
+# A backtick fence cannot be closed by tildes
+
+The block below opens with backticks and the author closed it with tildes. Markdown keeps the
+backtick fence open, so everything after the tilde line is code as far as any Markdown reader is
+concerned -- including the contradiction on the last line. The checker must agree and report an
+unterminated fence rather than accepting the file.
+
+```c
+static const sh8601_lcd_init_cmd_t lcd_init_cmds[] = {
+    {0x36, (uint8_t[]){0x00}, 1, 0},
+};
+~~~
+
+The display is a round AMOLED with 16.7 million colours and no backlight control.

--- a/scripts/fixtures/docs_identity/fence_short_closer.md
+++ b/scripts/fixtures/docs_identity/fence_short_closer.md
@@ -1,0 +1,12 @@
+# A short run cannot close a longer fence
+
+The block below opens with four backticks and the author closed it with three. A closing fence
+must be at least as long as the opener, so Markdown keeps the four-backtick fence open and the
+contradiction on the last line is inside it. The checker must report an unterminated fence
+rather than accepting the file.
+
+````text
+Nested example: ```c is the shape being documented here.
+```
+
+The display is a round AMOLED with 16.7 million colours and no backlight control.

--- a/scripts/fixtures/docs_identity/fence_valid.md
+++ b/scripts/fixtures/docs_identity/fence_valid.md
@@ -1,0 +1,32 @@
+# Valid Markdown fences stay exempt
+
+Every fence below is well formed: an info string on the opener, a tilde fence containing a
+backtick fence, a four-backtick fence closed by five backticks, and an indented fence. Quoting
+the guarded wordings as source is exactly what the exemption is for, so this file must produce
+zero violations.
+
+```c
+// Panel: 360x360 round AMOLED, 16.7 million colors, no backlight, ESP32-S3-WROOM-1
+// Press the knob to open the zone picker; backlight starts at 50% duty
+```
+
+~~~markdown
+An inner backtick fence, which is why the outer fence uses tildes:
+
+```text
+The display controller IC is the SH8601, per an earlier draft.
+```
+~~~
+
+````text
+A four-backtick fence closed by five, so the three-backtick line below is content:
+```
+The fitted touch controller is a CST816D and the panel is an AMOLED.
+`````
+
+   ```text
+   Indented three spaces, which is still a fence: no dimming control is possible.
+   ```
+
+The panel is a 360x360 round IPS LCD; the vendor declares an ST77916 driver IC and 262K
+colours, and the firmware drives an LEDC PWM backlight on GPIO 47.

--- a/scripts/fixtures/docs_identity/indented_code_scanned.md
+++ b/scripts/fixtures/docs_identity/indented_code_scanned.md
@@ -1,0 +1,12 @@
+# An indented block is scanned as prose
+
+The guarded wording below is indented four spaces, which makes it a CommonMark code block. It is
+**not** exempt: the checker scans indented lines as prose, so this file must produce violations and
+the report must name the remedy — fence the quotation instead of indenting it.
+
+    // Panel: 360x360 round AMOLED, 16.7 million colors, no backlight
+    static const sh8601_lcd_init_cmd_t lcd_init_cmds[] = {
+
+The same two lines inside a fenced block are exempt; `code_context_exempt.md` proves that. This
+file exists so the difference is discoverable from the output rather than only from the checker's
+docstring.

--- a/scripts/fixtures/docs_identity/other_target_marked.md
+++ b/scripts/fixtures/docs_identity/other_target_marked.md
@@ -1,0 +1,9 @@
+# Truthful facts about another board, with the marker
+
+The line below is true and is about a different product. It carries a line allowance that names
+the rule, names the other target, and gives a reason, so this file must produce zero violations.
+
+<!-- rk-ident-allow-next-line: PANEL_AMOLED,PRODUCT_NAME target="ESP32-S3-Touch-AMOLED-1.8" reason="comparison table entry for a different Waveshare product, which really does have that panel technology" -->
+The ESP32-S3-Touch-AMOLED-1.8 is a different Waveshare product with an AMOLED panel.
+
+Nothing else in this file asserts anything about the round knob target.

--- a/scripts/fixtures/docs_identity/other_target_no_reason.md
+++ b/scripts/fixtures/docs_identity/other_target_no_reason.md
@@ -1,0 +1,7 @@
+# A marker without a real reason is rejected
+
+The allowance below has an empty-ish reason, so it carries no review value and must be rejected
+as marker abuse.
+
+<!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-AMOLED-1.91" reason="because" -->
+The ESP32-S3-AMOLED-1.91 is a different Waveshare product with an AMOLED panel.

--- a/scripts/fixtures/docs_identity/other_target_second_line.md
+++ b/scripts/fixtures/docs_identity/other_target_second_line.md
@@ -1,0 +1,8 @@
+# One marker cannot cover two lines
+
+The allowance below is well formed and covers the line immediately after it. The line after
+*that* is not covered, so this file must still produce a violation.
+
+<!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-AMOLED-1.91" reason="comparison table entry for a different Waveshare product, which really does have that panel technology" -->
+The ESP32-S3-AMOLED-1.91 is a different Waveshare product with an AMOLED panel.
+And the round knob board has an AMOLED panel too, which is the claim being smuggled in.

--- a/scripts/fixtures/docs_identity/other_target_shipping.md
+++ b/scripts/fixtures/docs_identity/other_target_shipping.md
@@ -1,0 +1,7 @@
+# A marker cannot be claimed for the shipping target
+
+The allowance below names the shipping target itself, which is exactly the case the escape does
+not cover. It must be rejected as marker abuse.
+
+<!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-Knob-Touch-LCD-1.8" reason="trying to grant the current target an exemption from its own identity record" -->
+The ESP32-S3-Knob-Touch-LCD-1.8 has an AMOLED panel.

--- a/scripts/fixtures/docs_identity/other_target_unmarked.md
+++ b/scripts/fixtures/docs_identity/other_target_unmarked.md
@@ -1,0 +1,6 @@
+# The same truthful sentence without a marker
+
+The sentence below is true, but nothing marks it as being about another product, so the guard
+cannot tell it apart from a relapse. This file must produce a violation.
+
+The ESP32-S3-AMOLED-1.91 is a different Waveshare product with an AMOLED panel.

--- a/scripts/fixtures/docs_identity/other_target_unrelated_line.md
+++ b/scripts/fixtures/docs_identity/other_target_unrelated_line.md
@@ -1,0 +1,8 @@
+# A marker cannot silence a line that is not about the declared target
+
+The allowance below declares another product, but the line it covers says nothing about that
+product: it is a claim about the shipping target wearing someone else's permission slip. The
+allowance must be rejected as marker abuse.
+
+<!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-AMOLED-1.91" reason="pretending this line is about a different Waveshare product when it plainly is not" -->
+The round knob board's panel is a 360x360 round AMOLED.

--- a/scripts/fixtures/docs_identity/paraphrases.tsv
+++ b/scripts/fixtures/docs_identity/paraphrases.tsv
@@ -1,0 +1,31 @@
+# Independent paraphrase corpus for scripts/check_docs_identity.py (issue #211).
+#
+# Format: RULE_ID<TAB>sentence
+#
+# These sentences are the whole point of this file: they are authored *outside*
+# the checker, and none of them is a rule probe, a rule antiprobe or a copy of
+# any wording that ever appeared in this repository.  Each one is a way a
+# reviewer or a language model actually restated a #211 contradiction while the
+# first cut of the rule table stayed green.  If a rule is ever narrowed, these
+# fail before the repository goes quietly wrong again.
+#
+# Every sentence below is about the shipping target and is written as ordinary
+# prose -- no code fence, no backticks, no marker -- so each must be reported.
+#
+# Sentences that must NOT be reported live in paraphrases_clean.tsv.
+
+CONTROLLER_CLAIM	The SH8601 is the display driver IC fitted to this board.
+CONTROLLER_CLAIM	This board uses SH8601 silicon behind the QSPI bus.
+CONTROLLER_CLAIM	The panel controller is manufactured by Sitronix as the SH8601.
+NO_BACKLIGHT	The display has no backlight at all, so brightness is fixed.
+NO_BACKLIGHT	The screen is self-lit, so there is no dimming control.
+ENCODER_BUTTON	Click the dial to open the zone picker.
+ENCODER_BUTTON	Push the dial in to confirm the selection.
+ENCODER_BUTTON	The rotary shaft switch selects the highlighted zone.
+COLOR_DEPTH	The panel renders 16777216 distinct colours.
+COLOR_DEPTH	It is a 24-bit colour display.
+PANEL_AMOLED	The screen is an active-matrix organic LED panel.
+MODULE_CLAIM	The SoC is an ESP32S3 WROOM 1 module with 8 MB PSRAM.
+MODULE_CLAIM	The main chip is an ESP32-S3 WROOM1 N16R8.
+TOUCH_VARIANT	The touch controller is the CST816S part.
+BACKLIGHT_DUTY	The backlight starts at fifty percent brightness.

--- a/scripts/fixtures/docs_identity/paraphrases_clean.tsv
+++ b/scripts/fixtures/docs_identity/paraphrases_clean.tsv
@@ -1,0 +1,27 @@
+# Sentences that must produce NO violation (issue #211).
+#
+# Format: WHY<TAB>sentence
+#
+# The counterweight to paraphrases.tsv.  Strengthening a rule is only useful if
+# it stays a rule about a *claim* rather than a ban on a topic, so every one of
+# these is prose the repository is entitled to write: corrected identity facts,
+# qualified statements about what is unverified, and adjacent subject matter that
+# happens to share vocabulary with a guarded phrase.
+#
+# A rule that starts reporting one of these has become a topic ban and must be
+# narrowed, not exempted.
+
+corrected-driver-wording	The vendor declares an ST77916 driver IC; esp_lcd_sh8601 is the software component this project binds.
+corrected-panel	The panel is a 360x360 round IPS LCD declaring 262K colours.
+pixel-format-not-panel	RGB888 is a 24-bit colour pixel format; the panel itself still declares 262K colours.
+qualified-shaft-switch	Whether the encoder shaft has a push switch is unconfirmed on the owned unit.
+corrected-gesture	Tap the zone name to open the zone picker.
+family-not-variant	The vendor declares the CST816 family; the fitted marking is unverified.
+datasheet-reference	The vendor-linked datasheet is for the CST816D part.
+corrected-duty	Backlight on GPIO 47, initial duty CONFIG_RK_BACKLIGHT_NORMAL (100/255).
+corrected-soc	The vendor declares the SoC as ESP32-S3R8 with 8 MB PSRAM.
+dimming-is-a-feature	Automatic display dimming and sleep are configurable from the knob settings.
+firmware-reads-no-switch	This firmware reads rotation only; it reads no shaft switch on any GPIO.
+backlight-exists	The firmware drives an LEDC PWM backlight and can dim it on idle.
+sitronix-alone	Sitronix publishes the ST77916 datasheet the vendor declaration points at.
+sixteen-bit-is-fine	LVGL is configured for 16-bit colour, so each pixel is two bytes on the wire.

--- a/scripts/fixtures/docs_identity/report_all_groups.json
+++ b/scripts/fixtures/docs_identity/report_all_groups.json
@@ -1,0 +1,62 @@
+{
+  "exit_code": 3,
+  "files_scanned": [
+    ".github/RELEASE_TEMPLATE.md",
+    "README.md",
+    "docs/esp/hw-reference/board.md"
+  ],
+  "marker_abuse": [
+    {
+      "file": "docs/howto/PORTING.md",
+      "line": 42,
+      "message": "allowance names the shipping target 'ESP32-S3-Knob-Touch-LCD-1.8'; this escape exists only for truthful facts about other boards"
+    },
+    {
+      "file": "docs/esp/DISPLAY.md",
+      "line": 9,
+      "message": "carries the retired rk-ident-allow-file marker"
+    }
+  ],
+  "missing": [
+    "required document absent: docs/esp/ROTARY_ENCODER.md"
+  ],
+  "quoting_note": "quote source in a fenced code block (``` ... ```) if it is a quotation, not a claim: a four-space indented block is scanned as prose, not exempted as code, so indented source is reported here",
+  "root": "/synthetic/root",
+  "rules": [
+    {"id": "PRODUCT_NAME", "message": "wrong product name"},
+    {"id": "PANEL_AMOLED", "message": "the panel is an IPS LCD"}
+  ],
+  "selfcheck_failures": [
+    "PANEL_AMOLED: probe does not match its own pattern"
+  ],
+  "structure_failures": [
+    "docs/esp/hw-reference/board.md: corrected value 'ST77916' no longer present",
+    "docs/esp/DISPLAY.md:12: unterminated code fence opened here with 3 '`' and never closed"
+  ],
+  "suppressions": [
+    {
+      "file": "docs/esp/hw-reference/cst816d.md",
+      "line": 8,
+      "match": "CST816D",
+      "rule": "TOUCH_VARIANT",
+      "suppressor": "datasheet"
+    },
+    {
+      "file": "docs/esp/hw-reference/board.md",
+      "line": 118,
+      "match": "24-bit colour",
+      "rule": "COLOR_DEPTH",
+      "suppressor": "RGB888"
+    }
+  ],
+  "token": "RK-IDENT-MISSING",
+  "violations": [
+    {
+      "file": "docs/esp/hw-reference/board.md",
+      "line": 27,
+      "match": "AMOLED",
+      "message": "the panel is an IPS LCD, not an AMOLED; see the canonical record",
+      "rule": "PANEL_AMOLED"
+    }
+  ]
+}

--- a/scripts/fixtures/docs_identity/retired_marker.md
+++ b/scripts/fixtures/docs_identity/retired_marker.md
@@ -1,0 +1,5 @@
+<!-- rk-ident-allow-file: trying to silence the guard with the retired file-level marker -->
+
+# The retired marker earns a report of its own
+
+Panel: 360x360 round AMOLED, which the retired marker above used to hide.

--- a/scripts/fixtures/docs_identity/suppressed_hits.md
+++ b/scripts/fixtures/docs_identity/suppressed_hits.md
@@ -1,0 +1,18 @@
+# Truthful qualified prose passes, and says so out loud
+
+Each sentence below trips a rule pattern and is then excused by that rule's `unless` clause,
+because the qualification is what makes it truthful. None of them is a violation, so this file
+must exit 0 -- and every one of them must appear as a recorded suppression carrying the file,
+line, rule id and the text that did the excusing, so a widened suppressor is visible in review
+rather than only in the checker's regexes.
+
+The datasheet Waveshare publishes for this product describes the CST816D register map, which is
+why the family name is used in prose and the variant is listed as physically unverified.
+
+RGB888 is a 24-bit colour pixel format, and the panel still declares 262K colours; the format
+and the panel are different claims.
+
+Whether the encoder shaft is pressable at all is unconfirmed on the owned unit, so no document
+may state that it is.
+
+The stale comment says the backlight starts at 50 % duty; the configured value is 100/255.

--- a/scripts/fixtures/docs_identity/violation_BACKLIGHT_DUTY.md
+++ b/scripts/fixtures/docs_identity/violation_BACKLIGHT_DUTY.md
@@ -1,0 +1,3 @@
+# Display notes
+
+The firmware brings the backlight up at 50% duty on boot.

--- a/scripts/fixtures/docs_identity/violation_COLOR_DEPTH.md
+++ b/scripts/fixtures/docs_identity/violation_COLOR_DEPTH.md
@@ -1,0 +1,3 @@
+# Display notes
+
+Panel colour capability is 16.7 million colours at 360×360.

--- a/scripts/fixtures/docs_identity/violation_CONTROLLER_CLAIM.md
+++ b/scripts/fixtures/docs_identity/violation_CONTROLLER_CLAIM.md
@@ -1,0 +1,3 @@
+# Display notes
+
+The panel controller is an SH8601 reached over Quad SPI.

--- a/scripts/fixtures/docs_identity/violation_ENCODER_BUTTON.md
+++ b/scripts/fixtures/docs_identity/violation_ENCODER_BUTTON.md
@@ -1,0 +1,3 @@
+# Controls
+
+Press the knob to bring up the zone list, then turn it to choose a zone.

--- a/scripts/fixtures/docs_identity/violation_MODULE_CLAIM.md
+++ b/scripts/fixtures/docs_identity/violation_MODULE_CLAIM.md
@@ -1,0 +1,3 @@
+# Board notes
+
+The primary compute module fitted to this board is an ESP32-S3-WROOM-1 with 8 MB of PSRAM.

--- a/scripts/fixtures/docs_identity/violation_NO_BACKLIGHT.md
+++ b/scripts/fixtures/docs_identity/violation_NO_BACKLIGHT.md
@@ -1,0 +1,3 @@
+# Display notes
+
+There is no backlight pin to configure on this board, so brightness is a panel register.

--- a/scripts/fixtures/docs_identity/violation_PANEL_AMOLED.md
+++ b/scripts/fixtures/docs_identity/violation_PANEL_AMOLED.md
@@ -1,0 +1,3 @@
+# Display notes
+
+The firmware drives a 1.8 inch round AMOLED module at 360×360 over Quad SPI.

--- a/scripts/fixtures/docs_identity/violation_PRODUCT_NAME.md
+++ b/scripts/fixtures/docs_identity/violation_PRODUCT_NAME.md
@@ -1,0 +1,3 @@
+# Board notes
+
+GPIO pin assignments for the Waveshare ESP32-S3 Touch AMOLED 1.8" (360×360).

--- a/scripts/fixtures/docs_identity/violation_TOUCH_VARIANT.md
+++ b/scripts/fixtures/docs_identity/violation_TOUCH_VARIANT.md
@@ -1,0 +1,3 @@
+# Touch notes
+
+The fitted part is a CST816S touch controller reporting a single point over I2C.

--- a/scripts/summarize_docs_identity.py
+++ b/scripts/summarize_docs_identity.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Render a check_docs_identity.py JSON report as a GitHub step summary.
+
+Issue #211. Standard library only, no network, reads one file and writes Markdown
+to stdout.
+
+This lives in a file rather than in a heredoc inside the workflow for one reason:
+the heredoc version could not be tested, and it was wrong. It indexed every detail
+row as ``row["rule"]``, which is true of ``violations`` and false of
+``marker_abuse``, so the first marker-abuse finding turned the summary step into a
+``KeyError`` traceback -- on exactly the runs a reader most needs the summary.
+
+Contract, so the workflow can call it with ``if: always()``:
+
+*   Exit status is **always 0**. This is a reporting layer; it must never be the
+    thing that fails a run, and it must never mask the checker's own exit code.
+*   A missing, empty or malformed report is reported as such, in prose, and is
+    still exit 0.
+*   Absent or unexpected fields degrade to ``?`` or to a repr of the row rather
+    than raising. Report shapes drift; summaries should not crash on drift.
+*   Source-anchor freshness is counted, not given its own detail group. A stale
+    anchor is already a ``structure_failures`` row naming the anchor, the file and
+    the missing token, so rendering it twice would read as two findings.
+*   The anchor *count* is rendered with the report's own ``source_anchor_scope``
+    note directly beneath the table, because a bare count invites the two readings
+    it does not support: that every repository-observed row is anchored, and that
+    the line numbers those rows cite were checked. Neither is true. The note is
+    taken from the report rather than written here so the checker stays the single
+    place that states its own scope; a report without the field renders no note.
+*   The ``violations`` group is followed by the report's own ``quoting_note`` when
+    the report carries one, for the same reason as the anchor scope note: a
+    four-space indented block is scanned as prose rather than exempted as code, so
+    a reader looking at a violation on a line they meant as a quotation needs the
+    remedy -- fence it -- next to the finding. The text comes from the report so the
+    checker stays the single authority; a report without the field renders no note.
+*   Findings and informational rows are rendered separately. ``DETAIL_GROUPS`` are
+    findings: their presence is why a run is red. ``INFO_GROUPS`` -- currently
+    ``suppressions``, the hits a rule's ``unless`` clause excused -- are rendered
+    under their own heading and never affect the checker's exit code. They are
+    here so a widened suppressor is visible in the step summary rather than only
+    in the checker's regexes, and so the "nothing found" note below still appears
+    on a clean run that merely excused something.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+TOOL = "summarize_docs_identity"
+
+# Report keys rendered as detail sections, in reporting order. Every one of these
+# is a list; entries are dicts for the scanned findings and plain strings for the
+# structural ones.
+DETAIL_GROUPS = (
+    "violations",
+    "marker_abuse",
+    "structure_failures",
+    "missing",
+    "selfcheck_failures",
+)
+
+# Informational groups: rendered, counted, and deliberately excluded from the
+# "was anything found?" test that gates the closing note.
+INFO_GROUPS = ("suppressions",)
+
+INFO_NOTES = {
+    "suppressions": (
+        "Hits a rule's `unless` clause excused, so truthful qualified prose passes. "
+        "These do not affect the exit code; they are listed so a widened suppressor "
+        "is visible here rather than only in the checker's regexes."
+    ),
+}
+
+# Count rows: (label, report key). Neither the `rules` row nor the
+# `source anchors in table` row is a coverage number -- the first is the size of the
+# rule table, not a count of covered alternation branches; the second is the size of
+# the anchor table, not a count of repository-observed rows. A stale anchor is a
+# `structure_failures` row, so it is counted there rather than twice here.
+COUNT_ROWS = (
+    ("files scanned", "files_scanned"),
+    ("rules", "rules"),
+    ("source anchors in table", "source_anchors"),
+    ("violations", "violations"),
+    ("marker abuse", "marker_abuse"),
+    ("structure failures", "structure_failures"),
+    ("missing", "missing"),
+    ("self-check failures", "selfcheck_failures"),
+    ("suppressions (informational)", "suppressions"),
+)
+
+
+def _count(report, key):
+    value = report.get(key)
+    if isinstance(value, (list, tuple, dict)):
+        return str(len(value))
+    if isinstance(value, int):
+        return str(value)
+    return "?"
+
+
+def _rows(report, key):
+    value = report.get(key)
+    return value if isinstance(value, (list, tuple)) else []
+
+
+def format_row(row):
+    """One detail bullet.
+
+    Dict rows may or may not carry a ``rule`` -- ``violations`` do, ``marker_abuse``
+    does not -- and either may lack ``file``/``line`` in a degraded report. String
+    rows (``structure_failures``, ``missing``, ``selfcheck_failures``) pass through.
+    ``suppressions`` carry no ``message`` but do carry a ``suppressor``, which is
+    the evidence a reader needs, so it is appended rather than dropped.
+    """
+    if isinstance(row, str):
+        return "- %s" % row
+    if not isinstance(row, dict):
+        return "- %r" % (row,)
+
+    parts = []
+    rule = row.get("rule")
+    if rule:
+        parts.append("`%s`" % rule)
+
+    where = row.get("file")
+    if where:
+        line = row.get("line")
+        if isinstance(line, int) and line > 0:
+            where = "%s:%d" % (where, line)
+        parts.append(where)
+
+    text = row.get("message") or row.get("match")
+    suppressor = row.get("suppressor")
+    if suppressor:
+        text = "%s suppressed by `%s`" % (text or "match not recorded", suppressor)
+
+    if parts and text:
+        return "- %s — %s" % (" ".join(parts), text)
+    if parts:
+        return "- %s" % " ".join(parts)
+    if text:
+        return "- %s" % text
+    return "- %r" % (row,)
+
+
+def render(report, path=None):
+    """Return the summary as a list of Markdown lines."""
+    out = ["## Docs identity guard", ""]
+
+    if report is None:
+        out.append("No usable report at `%s`." % (path or "<unset>"))
+        out.append("")
+        out.append("The checker did not reach its reporting stage; read the step logs.")
+        return out
+
+    token = report.get("token", "?")
+    exit_code = report.get("exit_code", "?")
+    out.append("| Field | Value |")
+    out.append("|---|---|")
+    out.append("| token | `%s` |" % token)
+    out.append("| exit code | %s |" % exit_code)
+    for label, key in COUNT_ROWS:
+        out.append("| %s | %s |" % (label, _count(report, key)))
+
+    # The checker's own statement of what the anchor count does and does not mean.
+    # Rendered from the report so there is one authority for it; absent in an older
+    # or degraded report, in which case nothing is claimed here either.
+    scope = report.get("source_anchor_scope")
+    if isinstance(scope, str) and scope.strip():
+        out.append("")
+        out.append(scope.strip())
+
+    for group in DETAIL_GROUPS:
+        rows = _rows(report, group)
+        if not rows:
+            continue
+        out.append("")
+        out.append("### %s" % group.replace("_", " "))
+        for row in rows:
+            out.append(format_row(row))
+        # The indented-code consequence, in the checker's own words, beneath the
+        # findings it explains. Absent from an older or degraded report, in which
+        # case nothing is claimed here either.
+        if group == "violations":
+            quoting = report.get("quoting_note")
+            if isinstance(quoting, str) and quoting.strip():
+                out.append("")
+                out.append(quoting.strip())
+
+    for group in INFO_GROUPS:
+        rows = _rows(report, group)
+        if not rows:
+            continue
+        out.append("")
+        out.append("### %s (informational)" % group.replace("_", " "))
+        note = INFO_NOTES.get(group)
+        if note:
+            out.append("")
+            out.append(note)
+            out.append("")
+        for row in rows:
+            out.append(format_row(row))
+
+    if token == "RK-IDENT-OK" and not any(_rows(report, g) for g in DETAIL_GROUPS):
+        out.append("")
+        out.append(
+            "No guarded contradiction found in a known or tested wording. This is a "
+            "phrase tripwire, not a proof: see the checker's module docstring for what "
+            "it does and does not cover."
+        )
+
+    return out
+
+
+def load(path):
+    """Return the parsed report, or None if it cannot be used."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            report = json.load(handle)
+    except (OSError, ValueError):
+        return None
+    return report if isinstance(report, dict) else None
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        prog=TOOL,
+        description="Render a check_docs_identity.py JSON report as Markdown.",
+    )
+    parser.add_argument(
+        "--report",
+        default=None,
+        help="path to the JSON report (default: $RK_IDENT_REPORT)",
+    )
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit as exc:
+        if exc.code in (0, None):
+            # `--help`/`--version` already printed what was asked for. Emitting the
+            # "invoked incorrectly" summary on top of it would be a false report.
+            return 0
+        # Even a bad invocation must not fail the workflow step.
+        print("## Docs identity guard")
+        print()
+        print("The summary renderer was invoked incorrectly; read the step logs.")
+        return 0
+
+    path = args.report or os.environ.get("RK_IDENT_REPORT") or ""
+    report = load(path) if path else None
+    for line in render(report, path):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test_check_docs_identity.sh
+++ b/scripts/test_check_docs_identity.sh
@@ -1,0 +1,2180 @@
+#!/usr/bin/env bash
+# Host tests for scripts/check_docs_identity.py (issue #211).
+#
+# Deterministic, offline, no network, no writes inside the repository: every
+# mutation happens in a throwaway copy of the repository's Markdown under
+# $TMPDIR.
+#
+# The suite is built so it cannot pass vacuously:
+#   * every rule reported by --list-rules must have a fixture that makes it fire;
+#   * a file containing all the corrected wordings must produce zero violations;
+#   * the code exemption is proven not to swallow prose, and backticks alone are
+#     proven not to be an exemption;
+#   * the canonical record's *current-fact* sections are proven to be scanned, by
+#     mutating a live row of its identity table;
+#   * the section allowance is proven to be section-scoped, not file-scoped, and a
+#     heading that exists only inside an HTML comment is proven to neither clear it
+#     nor grant it -- section state is read from visible text;
+#   * every branch of the other-target line allowance is proven, in both
+#     directions;
+#   * the CHANGELOG.md skip is proven to be exactly one root-level file;
+#   * fenced code is exempt only when the fence is well formed: an unterminated,
+#     mismatched or short-closed fence, and an unterminated HTML comment, are all
+#     proven to FAIL loudly instead of absorbing the rest of the file;
+#   * rule-level `unless` suppressions are proven observable in the report, the
+#     counters and the step summary, and removing that observability is proven to
+#     fail --self-check, and the repository's suppression *set* is pinned as an
+#     exact rule|file|suppressor|count fingerprint -- whose shape is proven against a
+#     fixed synthetic set, not the live one, to discriminate a one-for-one
+#     substitution at unchanged total, to discriminate an additional suppressed hit
+#     inside an already-pinned triple, and to stay independent of line numbers and
+#     matched prose -- so a widened suppressor becomes review friction;
+#   * a four-space indented block is proven to be scanned as prose rather than
+#     exempted as code, and the violation output, the JSON report and the step
+#     summary are proven to name the remedy (fence the quotation), because that is
+#     the one exemption a reader expects and does not get;
+#   * source anchors are proven discriminating in both directions -- mutating one
+#     expected token and deleting one cited source file each produce a named,
+#     non-zero STRUCTURE finding, and neither is worded as proof the claim is false;
+#   * anchor tokens are proven relationship-preserving: splitting one whole-line
+#     token into independently-satisfiable halves is proven to fail --self-check,
+#     and a token is proven not to match a longer identifier or literal;
+#   * anchor whitespace flexibility is proven bounded on both sides: a punctuation
+#     join may close entirely (the QSPI macro call is pinned both spaced and
+#     unspaced on one line) while whitespace between two word lexemes stays
+#     mandatory, so fusing two identifiers is proven not to satisfy a token;
+#   * --quiet is proven to gate only the per-hit suppression and violation lines,
+#     and its help text is pinned to that behaviour;
+#   * the step renderer is proven to answer --help with argparse's help rather than
+#     with its "invoked incorrectly" summary, while still naming a real bad
+#     invocation, and to exit 0 in both cases;
+#   * the guard is proven reachable locally as a direct host-only command that both
+#     AGENTS.md and docs/dev/DEVELOPMENT.md name;
+#
+# What the suite does NOT assert, deliberately:
+#   * that the cited *line numbers* in the canonical record are correct. Anchors
+#     check text, so pure line movement leaves a citation stale with every token
+#     present. Asserting line numbers here would make every unrelated edit above a
+#     cited line a red documentation guard. That is human review, tracked in #213;
+#   * that the anchor table covers every repository-observed row. It covers a
+#     subset; negative, uniqueness, derived and physical rows are not anchorable.
+#   * an empty tree, a deleted canonical record and a gutted one must all FAIL;
+#   * the checker's own --self-check is proven live by breaking a copy of it.
+#
+# The suite deliberately does *not* assert that the rule count equals the number of
+# covered alternation branches. Each rule is an alternation; the per-rule fixture
+# proves one clause fires. Individual clauses are pinned only by paraphrases.tsv.
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECKER="$REPO/scripts/check_docs_identity.py"
+FIXTURES="$REPO/scripts/fixtures/docs_identity"
+BOARD="docs/esp/hw-reference/board.md"
+ADR="docs/meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md"
+
+PY="${PYTHON:-python3}"
+
+# The repository's current suppression *set*, pinned as an exact fingerprint: one
+# `rule|file|suppressor|count` line per distinct triple, sorted by Python's
+# codepoint order (not the shell's, so the locale cannot move a line).
+#
+# The trailing count is load-bearing. Without it, a triple that already appears in
+# the baseline is a standing licence: a second, third and fourth sentence in the
+# same file could take the same excuse from the same rule and the fingerprint would
+# not move, which is a widening of exactly the kind this baseline exists to make
+# visible. With it, every additional suppressed hit in an existing triple fails,
+# and the diff says how many.
+#
+# Line numbers and matched prose are still deliberately excluded, and the count is
+# not a substitute for them: it says how many hits a triple excuses, never which
+# lines or which words. They churn on every unrelated edit above a suppressed line
+# and on every rewording of the sentence, so including them would make this
+# baseline fail constantly for reasons that are not the thing being watched. What IS
+# being watched is which suppressor excuses which rule in which file, and how often
+# -- so swapping one suppressor for another, moving a suppressed hit to a different
+# file, or adding one to a triple already listed all fail. A scalar total could see
+# none of the three.
+#
+# See the "the suppression fingerprint is pinned" block near the end of this file
+# for what to do when it fails.
+EXPECTED_SUPPRESSION_FINGERPRINT="$(cat <<'EOF'
+BACKLIGHT_DUTY|docs/esp/hw-reference/board.md|stale|1
+BACKLIGHT_DUTY|docs/meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md|stale|1
+TOUCH_VARIANT|docs/esp/TOUCH_INPUT.md|datasheet|1
+TOUCH_VARIANT|docs/esp/hw-reference/board.md|marking|1
+TOUCH_VARIANT|docs/esp/hw-reference/cst816d.md|Datasheet|1
+TOUCH_VARIANT|docs/esp/hw-reference/cst816d.md|datasheet|1
+EOF
+)"
+
+# fingerprint <report.json> -> sorted `rule|file|suppressor|count` lines on stdout
+#
+# One line per distinct triple, carrying the number of suppressed hits it covers.
+# `line` and `match` are never read, which is what keeps the baseline quiet on line
+# movement and rewording; the count is what keeps it loud on an extra hit.
+fingerprint() {
+  "$PY" -c '
+import collections, json, sys
+rows = json.load(open(sys.argv[1])).get("suppressions", [])
+counts = collections.Counter(
+    "%s|%s|%s" % (r.get("rule"), r.get("file"), r.get("suppressor")) for r in rows
+)
+for key in sorted(counts):
+    print("%s|%d" % (key, counts[key]))
+' "$1" 2>/dev/null
+}
+
+PASS=0
+FAIL=0
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/rk-ident-tests.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+# Source files the checker's SOURCE_ANCHORS cite, asked of the checker rather than
+# duplicated here, so adding an anchor cannot leave the temporary roots behind.
+# `fresh_tree` copies exactly these and nothing else from idf_app/, which keeps a
+# throwaway root self-contained without dragging in the firmware tree.
+ANCHOR_PATHS="$("$PY" "$CHECKER" --list-anchors 2>/dev/null | cut -f2 | sort -u)"
+
+ok() { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  FAIL %s\n' "$1"; }
+
+# run <root> [extra args...] -> sets RUN_OUT and RUN_RC
+run() {
+  local root="$1"
+  shift
+  RUN_OUT="$("$PY" "$CHECKER" --root "$root" "$@" 2>/dev/null)"
+  RUN_RC=$?
+}
+
+# expect_rc <label> <want_rc> <root> [extra args...]
+expect_rc() {
+  local label="$1" want="$2" root="$3"
+  shift 3
+  run "$root" "$@"
+  if [ "$RUN_RC" -eq "$want" ]; then
+    ok "$label (exit $want)"
+  else
+    bad "$label: wanted exit $want, got $RUN_RC"
+    printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+  fi
+}
+
+# expect_out <label> <needle>  (inspects the last run)
+expect_out() {
+  local label="$1" needle="$2"
+  if printf '%s' "$RUN_OUT" | grep -qF -- "$needle"; then
+    ok "$label"
+  else
+    bad "$label: output did not contain '$needle'"
+    printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+  fi
+}
+
+expect_no_out() {
+  local label="$1" needle="$2"
+  if printf '%s' "$RUN_OUT" | grep -qF -- "$needle"; then
+    bad "$label: output unexpectedly contained '$needle'"
+    printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+  else
+    ok "$label"
+  fi
+}
+
+# fresh_tree <name> -> echoes a path holding a pristine copy of the scanned tree
+#
+# Self-contained: the scanned Markdown, plus exactly the source files SOURCE_ANCHORS
+# cites (asked of the checker, not hard-coded), and nothing else. Without the
+# anchor files every throwaway root would report a wall of stale-citation structure
+# failures that have nothing to do with the case under test.
+fresh_tree() {
+  local dest="$WORK/$1" src
+  rm -rf "$dest"
+  mkdir -p "$dest"
+  cp -R "$REPO/docs" "$dest/docs"
+  cp "$REPO/README.md" "$dest/README.md"
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    mkdir -p "$dest/$(dirname "$src")"
+    cp "$REPO/$src" "$dest/$src"
+  done <<< "$ANCHOR_PATHS"
+  printf '%s' "$dest"
+}
+
+# rewrite <file> <sed script>  -- edit in place inside a throwaway tree
+rewrite() {
+  local target="$1" script="$2"
+  sed "$script" "$target" > "$target.tmp" && mv "$target.tmp" "$target"
+}
+
+echo "== baseline =="
+
+expect_rc "real repository docs are accepted" 0 "$REPO" --self-check
+expect_out "baseline prints the OK token" "RK-IDENT-OK"
+expect_no_out "baseline reports no violations" "RK-IDENT-VIOLATION"
+expect_no_out "baseline reports no marker abuse" "RK-IDENT-MARKER-ABUSE"
+
+BASE="$(fresh_tree baseline)"
+expect_rc "pristine copy of the doc tree is accepted" 0 "$BASE"
+
+echo "== the scan is repo-wide, not docs-only =="
+
+ROOTLEVEL="$(fresh_tree rootlevel)"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$ROOTLEVEL/AGENTS.md"
+expect_rc "a contradiction in a root-level non-docs file is caught" 1 "$ROOTLEVEL"
+expect_out "the root-level file is named" "AGENTS.md"
+
+NESTED="$(fresh_tree nested)"
+mkdir -p "$NESTED/web/notes"
+cp "$FIXTURES/violation_CONTROLLER_CLAIM.md" "$NESTED/web/notes/panel.md"
+expect_rc "a contradiction outside docs/ is caught" 1 "$NESTED"
+expect_out "the nested file is named" "web/notes/panel.md"
+
+echo "== .github is scanned, and the exclusions are exactly the named ones =="
+
+# The documented scope said "every Markdown file in the repository" while the
+# implementation excluded every dot-directory, so .github/RELEASE_TEMPLATE.md --
+# release prose that describes the target -- was never read. Pin the real file.
+SCOPEREPORT="$WORK/scope.json"
+run "$REPO" --self-check --report "$SCOPEREPORT"
+if [ -s "$SCOPEREPORT" ] && "$PY" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+assert '.github/RELEASE_TEMPLATE.md' in d['files_scanned'], [f for f in d['files_scanned'] if f.startswith('.')]
+" "$SCOPEREPORT" 2>/dev/null; then
+  ok ".github/RELEASE_TEMPLATE.md is in the scanned file list"
+else
+  bad ".github/RELEASE_TEMPLATE.md was not scanned"
+fi
+
+GH="$(fresh_tree github_scanned)"
+mkdir -p "$GH/.github/ISSUE_TEMPLATE"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$GH/.github/RELEASE_TEMPLATE.md"
+expect_rc "a contradiction in .github/RELEASE_TEMPLATE.md is caught" 1 "$GH"
+expect_out "the .github file is named" ".github/RELEASE_TEMPLATE.md"
+
+GHNEST="$(fresh_tree github_nested)"
+mkdir -p "$GHNEST/.github/ISSUE_TEMPLATE"
+cp "$FIXTURES/violation_CONTROLLER_CLAIM.md" "$GHNEST/.github/ISSUE_TEMPLATE/bug.md"
+expect_rc "a contradiction nested under .github is caught" 1 "$GHNEST"
+expect_out "the nested .github file is named" ".github/ISSUE_TEMPLATE/bug.md"
+
+# No dot-directory rule at all: a directory is exempt only by exact name.
+DOTDIR="$(fresh_tree dot_directory)"
+mkdir -p "$DOTDIR/.notes"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$DOTDIR/.notes/scratch.md"
+expect_rc "an unlisted dot-directory is still scanned" 1 "$DOTDIR"
+expect_out "the dot-directory file is named" ".notes/scratch.md"
+
+# ... and the named exclusions really do exclude. All of them at once, so a
+# missing entry shows up as a failure rather than as a passing subset.
+EXCL="$(fresh_tree exclusions)"
+for d in build node_modules managed_components dependencies __pycache__ .venv venv \
+         .mypy_cache .pytest_cache .ruff_cache; do
+  mkdir -p "$EXCL/$d/nested"
+  cp "$FIXTURES/violation_PANEL_AMOLED.md" "$EXCL/$d/nested/scratch.md"
+done
+expect_rc "every named excluded directory is excluded, at depth" 0 "$EXCL"
+
+echo "== a link label that is a filename is a reference, not a claim =="
+
+LABEL="$(fresh_tree link_label)"
+{
+  printf '# Cross references\n\n'
+  printf -- '- [cst816d.md](../esp/hw-reference/cst816d.md) - integration notes\n'
+} > "$LABEL/docs/scratch.md"
+expect_rc "a filename link label does not trip TOUCH_VARIANT" 0 "$LABEL"
+
+LABELPROSE="$(fresh_tree link_label_prose)"
+{
+  printf '# Not a reference\n\n'
+  printf 'The fitted touch controller is a CST816D on this unit.\n'
+} > "$LABELPROSE/docs/scratch.md"
+expect_rc "the same variant asserted in prose is still rejected" 1 "$LABELPROSE"
+expect_out "prose variant assertion names TOUCH_VARIANT" "RK-IDENT-VIOLATION: TOUCH_VARIANT"
+
+echo "== the CHANGELOG skip is exactly one root-level file =="
+
+CHANGELOG="$(fresh_tree changelog)"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$CHANGELOG/CHANGELOG.md"
+expect_rc "bot-managed root CHANGELOG.md is skipped" 0 "$CHANGELOG"
+
+CHANGEELSE="$(fresh_tree changelog_elsewhere)"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$CHANGEELSE/docs/CHANGELOG.md"
+expect_rc "docs/CHANGELOG.md does not inherit the skip" 1 "$CHANGEELSE"
+expect_out "docs/CHANGELOG.md is named" "docs/CHANGELOG.md"
+
+CHANGENEAR="$(fresh_tree changelog_lookalike)"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$CHANGENEAR/CHANGELOG_NOTES.md"
+expect_rc "a similarly named root file does not inherit the skip" 1 "$CHANGENEAR"
+expect_out "the lookalike file is named" "CHANGELOG_NOTES.md"
+
+echo "== fixture corpus is not scanned, and the skip is scoped =="
+
+FIXSCAN="$(fresh_tree fixscan)"
+mkdir -p "$FIXSCAN/scripts/fixtures/docs_identity"
+cp "$FIXTURES"/violation_*.md "$FIXSCAN/scripts/fixtures/docs_identity/"
+expect_rc "contradictions under scripts/fixtures are skipped" 0 "$FIXSCAN"
+
+FIXELSE="$(fresh_tree fixelsewhere)"
+mkdir -p "$FIXELSE/docs/fixtures"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$FIXELSE/docs/fixtures/scratch.md"
+expect_rc "the same file elsewhere is still scanned" 1 "$FIXELSE"
+
+echo "== every rule has a fixture, and every fixture fires =="
+
+RULES="$("$PY" "$CHECKER" --list-rules 2>/dev/null)"
+RULE_RC=$?
+if [ "$RULE_RC" -eq 0 ] && [ -n "$RULES" ]; then
+  ok "--list-rules exits 0 and prints rule ids"
+else
+  bad "--list-rules failed (rc=$RULE_RC)"
+fi
+
+RULE_COUNT=0
+while IFS= read -r rule; do
+  [ -n "$rule" ] || continue
+  RULE_COUNT=$((RULE_COUNT + 1))
+  fixture="$FIXTURES/violation_${rule}.md"
+  if [ ! -f "$fixture" ]; then
+    bad "rule $rule has no fixture at scripts/fixtures/docs_identity/violation_${rule}.md"
+    continue
+  fi
+  tree="$(fresh_tree "rule_$rule")"
+  cp "$fixture" "$tree/docs/scratch.md"
+  run "$tree"
+  if [ "$RUN_RC" -eq 1 ] && printf '%s' "$RUN_OUT" | grep -qF "RK-IDENT-VIOLATION: $rule "; then
+    ok "rule $rule fires on its fixture and exits 1"
+  else
+    bad "rule $rule did not fire on its fixture (rc=$RUN_RC)"
+    printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+  fi
+done <<< "$RULES"
+
+# Population only. This is not a coverage number: each rule is an alternation and
+# the loop above proves one clause of it fires, not all of them.
+if [ "$RULE_COUNT" -ge 9 ]; then
+  ok "rule table is populated ($RULE_COUNT rules; not a branch-coverage figure)"
+else
+  bad "expected at least 9 rules, found $RULE_COUNT"
+fi
+
+# Governance triggers belong beside the rules they constrain. Pin their unique
+# text so a refactor cannot silently drop the revise/retire path that #213 relies on.
+for trigger in \
+  "this rule guards today's target, not permanent product policy" \
+  "a future target may truthfully carry this panel technology" \
+  "this rule guards a currently phantom input, not future policy"; do
+  if grep -qF "$trigger" "$CHECKER"; then
+    ok "rule-local governance trigger remains documented: $trigger"
+  else
+    bad "rule-local governance trigger disappeared: $trigger"
+  fi
+done
+
+echo "== rules are specific, not blanket topic bans =="
+
+CLEAN="$(fresh_tree clean_all)"
+cp "$FIXTURES/clean_all.md" "$CLEAN/docs/scratch.md"
+expect_rc "all corrected wordings together produce no violations" 0 "$CLEAN"
+
+echo "== independent paraphrases are caught, one sentence at a time =="
+
+# The point of this block: none of these sentences is a rule probe, a rule
+# antiprobe, or a wording that ever appeared in this repository. A rule that only
+# matches its own probe passes the per-rule fixture loop above and still has no
+# recall, which is exactly what a dissent pass demonstrated. Each sentence is
+# planted alone, so a failure names the sentence rather than the file.
+PARA="$FIXTURES/paraphrases.tsv"
+if [ ! -f "$PARA" ]; then
+  bad "paraphrase corpus missing at scripts/fixtures/docs_identity/paraphrases.tsv"
+else
+  PARA_TREE="$(fresh_tree paraphrase)"
+  PARA_N=0
+  while IFS="$(printf '\t')" read -r rule sentence; do
+    case "$rule" in ''|'#'*) continue ;; esac
+    [ -n "$sentence" ] || continue
+    PARA_N=$((PARA_N + 1))
+    {
+      printf '# Paraphrase %d\n\n' "$PARA_N"
+      printf '%s\n' "$sentence"
+    } > "$PARA_TREE/docs/scratch.md"
+    run "$PARA_TREE"
+    if [ "$RUN_RC" -eq 1 ] && printf '%s' "$RUN_OUT" | grep -qF "RK-IDENT-VIOLATION: $rule "; then
+      ok "paraphrase caught by $rule: $sentence"
+    else
+      bad "paraphrase NOT caught by $rule (rc=$RUN_RC): $sentence"
+      printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+    fi
+  done < "$PARA"
+  rm -f "$PARA_TREE/docs/scratch.md"
+  if [ "$PARA_N" -ge 15 ]; then
+    ok "paraphrase corpus is populated ($PARA_N sentences)"
+  else
+    bad "expected at least 15 paraphrases, found $PARA_N"
+  fi
+fi
+
+echo "== physical-line wrapping is an explicit known limit =="
+
+# The scanner records prose per physical line. Pin this current blind spot rather
+# than implying the single-line paraphrase corpus covers hard-wrapped prose; #213
+# owns changing the mechanism and flipping this expectation.
+WRAPPED_CLAIM="$(fresh_tree wrapped_controller_claim)"
+{
+  printf '# Wrapped controller claim\n\n'
+  printf 'The SH8601 is the display\n'
+  printf 'controller for this board.\n'
+} > "$WRAPPED_CLAIM/docs/scratch.md"
+expect_rc "a controller claim split across physical lines remains outside current recall" \
+  0 "$WRAPPED_CLAIM"
+expect_no_out "the wrapped known limit is not presented as a caught controller claim" \
+  "RK-IDENT-VIOLATION: CONTROLLER_CLAIM"
+
+WRAPPED_DUTY="$(fresh_tree wrapped_backlight_duty)"
+{
+  printf '# Wrapped duty claim\n\n'
+  printf 'The backlight starts at fifty percent\n'
+  printf 'brightness.\n'
+} > "$WRAPPED_DUTY/docs/scratch.md"
+expect_rc "a backlight-duty claim split across physical lines remains outside current recall" \
+  0 "$WRAPPED_DUTY"
+expect_no_out "the wrapped known limit is not presented as a caught duty claim" \
+  "RK-IDENT-VIOLATION: BACKLIGHT_DUTY"
+
+WRAPPED_BUTTON="$(fresh_tree wrapped_encoder_button)"
+{
+  printf '# Wrapped encoder-button claim\n\n'
+  printf 'Press the\n'
+  printf 'knob to open the zone picker.\n'
+} > "$WRAPPED_BUTTON/docs/scratch.md"
+expect_rc "an encoder-button claim split across physical lines remains outside current recall" \
+  0 "$WRAPPED_BUTTON"
+expect_no_out "the wrapped known limit is not presented as a caught button claim" \
+  "RK-IDENT-VIOLATION: ENCODER_BUTTON"
+
+echo "== truthful prose that shares vocabulary stays clean =="
+
+# The counterweight: strengthening a rule must not turn it into a topic ban.
+CLEANPARA="$FIXTURES/paraphrases_clean.tsv"
+if [ ! -f "$CLEANPARA" ]; then
+  bad "clean paraphrase corpus missing at scripts/fixtures/docs_identity/paraphrases_clean.tsv"
+else
+  CLEAN_TREE="$(fresh_tree paraphrase_clean)"
+  CLEAN_N=0
+  while IFS="$(printf '\t')" read -r why sentence; do
+    case "$why" in ''|'#'*) continue ;; esac
+    [ -n "$sentence" ] || continue
+    CLEAN_N=$((CLEAN_N + 1))
+    {
+      printf '# Clean paraphrase %d\n\n' "$CLEAN_N"
+      printf '%s\n' "$sentence"
+    } > "$CLEAN_TREE/docs/scratch.md"
+    run "$CLEAN_TREE"
+    if [ "$RUN_RC" -eq 0 ]; then
+      ok "truthful prose accepted ($why)"
+    else
+      bad "truthful prose rejected ($why, rc=$RUN_RC): $sentence"
+      printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+    fi
+  done < "$CLEANPARA"
+  rm -f "$CLEAN_TREE/docs/scratch.md"
+  if [ "$CLEAN_N" -ge 10 ]; then
+    ok "clean corpus is populated ($CLEAN_N sentences)"
+  else
+    bad "expected at least 10 clean sentences, found $CLEAN_N"
+  fi
+fi
+
+echo "== the other-board escape survives the strengthened rules =="
+
+# Strengthening the rules must not remove the one truthful way out. Same guarded
+# vocabulary, a different board, one marker per line.
+ESCAPE="$(fresh_tree strengthened_escape)"
+{
+  printf '# Comparison with other boards\n\n'
+  printf '<!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-AMOLED-1.91" reason="the 1.91 inch sibling really does ship an active-matrix organic LED panel" -->\n'
+  printf 'The ESP32-S3-AMOLED-1.91 uses an active-matrix organic LED panel.\n\n'
+  # Two rules on one line: the sibling's product name contains the panel
+  # technology, so the marker must list both ids and both must really fire.
+  printf '<!-- rk-ident-allow-next-line: PANEL_AMOLED, COLOR_DEPTH target="ESP32-S3-AMOLED-1.91" reason="the 1.91 inch sibling really is a 24-bit colour panel per its own datasheet" -->\n'
+  printf 'The ESP32-S3-AMOLED-1.91 is a 24-bit colour display.\n\n'
+  printf '<!-- rk-ident-allow-next-line: MODULE_CLAIM target="T-Display-S3" reason="that board genuinely carries the module package named here, unlike our target" -->\n'
+  printf 'The T-Display-S3 carries an ESP32S3 WROOM 1 module.\n'
+} > "$ESCAPE/docs/scratch.md"
+expect_rc "marked other-board paraphrases still pass" 0 "$ESCAPE"
+
+ESCAPESHIP="$(fresh_tree strengthened_escape_ship)"
+{
+  printf '# Not an escape for our own board\n\n'
+  printf '<!-- rk-ident-allow-next-line: COLOR_DEPTH target="ESP32-S3-Knob-Touch-LCD-1.8" reason="attempting to use the other-board escape on the shipping target itself" -->\n'
+  printf 'The ESP32-S3-Knob-Touch-LCD-1.8 is a 24-bit colour display.\n'
+} > "$ESCAPESHIP/docs/scratch.md"
+expect_rc "the escape still refuses the shipping target on a new rule clause" 1 "$ESCAPESHIP"
+expect_out "shipping-target abuse is named for the new clause" "names the shipping target"
+
+echo "== code context is exempt, prose is not =="
+
+EXEMPT="$(fresh_tree code_exempt)"
+cp "$FIXTURES/code_context_exempt.md" "$EXEMPT/docs/scratch.md"
+expect_rc "guarded phrases inside fences and link targets are exempt" 0 "$EXEMPT"
+
+BARE="$(fresh_tree code_bare)"
+cp "$FIXTURES/code_context_bare.md" "$BARE/docs/scratch.md"
+expect_rc "the same phrases as prose are rejected" 1 "$BARE"
+expect_out "prose case names PANEL_AMOLED" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+expect_out "prose case names CONTROLLER_CLAIM" "RK-IDENT-VIOLATION: CONTROLLER_CLAIM"
+expect_out "prose case names ENCODER_BUTTON" "RK-IDENT-VIOLATION: ENCODER_BUTTON"
+expect_out "prose case names BACKLIGHT_DUTY" "RK-IDENT-VIOLATION: BACKLIGHT_DUTY"
+expect_out "prose case names TOUCH_VARIANT" "RK-IDENT-VIOLATION: TOUCH_VARIANT"
+
+echo "== an indented block is scanned as prose, and the output says so =="
+
+# The deliberate gap in the code exemption. A four-space indented block is code to
+# CommonMark and is NOT exempt here: recognising it would mean tracking list and
+# blockquote context to tell a code block from a continuation line, and an
+# indentation-only exemption would exempt the reflowed middle of a paragraph -- which
+# is how the guarded wording travelled through this repository in the first place.
+#
+# Keeping that gap is only defensible if it is discoverable, so this asserts both
+# halves: the block is reported, and the report names the remedy. An author who
+# indented a quotation must not have to read the checker's docstring to find out why
+# their quotation became a claim.
+INDENTED="$(fresh_tree indented_code)"
+cp "$FIXTURES/indented_code_scanned.md" "$INDENTED/docs/scratch.md"
+expect_rc "a four-space indented block is scanned, not exempted" 1 "$INDENTED"
+expect_out "the indented block names PANEL_AMOLED" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+expect_out "the indented block names NO_BACKLIGHT" "RK-IDENT-VIOLATION: NO_BACKLIGHT"
+expect_out "the violation output tells the author to fence a quotation" \
+  "quote source in a fenced code block"
+expect_out "the violation output names the cause, not just the remedy" \
+  "a four-space indented block is scanned as prose"
+
+# The same text fenced is exempt, which is what makes the remedy a real one rather
+# than advice that does not work.
+INDENT_FENCED="$(fresh_tree indented_code_fenced)"
+{
+  printf '# Fencing the same block is the remedy\n\n```c\n'
+  sed -n 's/^    //p' "$FIXTURES/indented_code_scanned.md"
+  printf '```\n'
+} > "$INDENT_FENCED/docs/scratch.md"
+if ! grep -q 'AMOLED' "$INDENT_FENCED/docs/scratch.md"; then
+  bad "could not build the fenced counterpart (the indented block did not transfer)"
+else
+  expect_rc "the same block inside a fence is exempt" 0 "$INDENT_FENCED"
+  expect_no_out "the fenced counterpart prints no quoting note" "quote source in a fenced code block"
+fi
+
+# The note is not a rule message: it belongs to the run, travels in the report so the
+# step summary can render it, and is printed once rather than per hit.
+INDENT_REPORT="$WORK/indented_code_report.json"
+run "$INDENTED" --report "$INDENT_REPORT"
+if "$PY" -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+note = d.get("quoting_note", "")
+assert "fenced code block" in note, note
+assert "indented" in note, note
+assert d["violations"], "the fixture reported no violations"
+' "$INDENT_REPORT" 2>/dev/null; then
+  ok "the report carries the quoting note alongside the violations"
+else
+  bad "the report does not carry a usable quoting_note"
+fi
+NOTE_LINES="$(printf '%s\n' "$RUN_OUT" | grep -c "quote source in a fenced code block")"
+if [ "$NOTE_LINES" -eq 1 ]; then
+  ok "the quoting note is printed once, not once per hit"
+else
+  bad "the quoting note appeared $NOTE_LINES times, wanted exactly 1"
+fi
+
+echo "== backticks alone are not an exemption =="
+
+IDENTS="$(fresh_tree code_identifiers)"
+cp "$FIXTURES/code_identifiers.md" "$IDENTS/docs/scratch.md"
+expect_rc "backtick spans carrying a code signal stay exempt" 0 "$IDENTS"
+
+TICKS="$(fresh_tree backtick_claims)"
+cp "$FIXTURES/backtick_claims.md" "$TICKS/docs/scratch.md"
+expect_rc "backticked product and panel claims are rejected" 1 "$TICKS"
+expect_out "backticked panel claim names PANEL_AMOLED" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+expect_out "backticked colour claim names COLOR_DEPTH" "RK-IDENT-VIOLATION: COLOR_DEPTH"
+expect_out "backticked controller claim names CONTROLLER_CLAIM" "RK-IDENT-VIOLATION: CONTROLLER_CLAIM"
+expect_out "backticked module claim names MODULE_CLAIM" "RK-IDENT-VIOLATION: MODULE_CLAIM"
+expect_out "backticked product name names PRODUCT_NAME" "RK-IDENT-VIOLATION: PRODUCT_NAME"
+expect_out "backticked backlight claim names NO_BACKLIGHT" "RK-IDENT-VIOLATION: NO_BACKLIGHT"
+
+echo "== fenced code is exempt only when the fence is well formed =="
+
+# The fence exemption is the widest one the checker has, so a fence the checker
+# thinks is open when Markdown does not -- or the reverse -- silently exempts real
+# prose. These cases pin both directions.
+FENCEOK="$(fresh_tree fence_valid)"
+cp "$FIXTURES/fence_valid.md" "$FENCEOK/docs/scratch.md"
+expect_rc "well-formed fences of every shape stay exempt" 0 "$FENCEOK"
+expect_no_out "a valid fence is not reported as unterminated" "unterminated code fence"
+
+MISFENCE="$(fresh_tree fence_mismatched)"
+cp "$FIXTURES/fence_mismatched.md" "$MISFENCE/docs/scratch.md"
+expect_rc "a backtick fence closed by tildes is a structure failure" 2 "$MISFENCE"
+expect_out "the mismatched fence is named" "RK-IDENT-STRUCTURE: docs/scratch.md:8: unterminated code fence"
+expect_no_out "a mismatched fence can never report OK" "RK-IDENT-OK"
+
+SHORTFENCE="$(fresh_tree fence_short_closer)"
+cp "$FIXTURES/fence_short_closer.md" "$SHORTFENCE/docs/scratch.md"
+expect_rc "a four-backtick fence closed by three is a structure failure" 2 "$SHORTFENCE"
+expect_out "the short closer is named with the opening run length" \
+  "unterminated code fence opened here with 4"
+expect_no_out "a short-closed fence can never report OK" "RK-IDENT-OK"
+
+# A bare unterminated opener, with nothing after it, is still reported: the defect
+# is the structure, not the contradiction it happens to hide.
+BAREFENCE="$(fresh_tree fence_bare_unterminated)"
+{
+  printf '# Unterminated fence with nothing after it\n\n'
+  printf '```text\n'
+  printf 'The block was never closed.\n'
+} > "$BAREFENCE/docs/scratch.md"
+expect_rc "an unterminated fence fails even with no contradiction behind it" 2 "$BAREFENCE"
+expect_out "the bare unterminated fence is named" "docs/scratch.md:3: unterminated code fence"
+
+# Tildes are symmetric: a tilde fence closed by backticks is equally unterminated.
+TILDEFENCE="$(fresh_tree fence_tilde_mismatch)"
+{
+  printf '# Tilde fence closed by backticks\n\n'
+  printf '~~~text\n'
+  printf 'Quoted source.\n'
+  printf '```\n\n'
+  printf 'The display is a round AMOLED with no backlight control.\n'
+} > "$TILDEFENCE/docs/scratch.md"
+expect_rc "a tilde fence closed by backticks is a structure failure" 2 "$TILDEFENCE"
+expect_out "the tilde fence is named with its character" "unterminated code fence opened here with 3 '~'"
+
+echo "== an unterminated HTML comment cannot hide the tail =="
+
+COMMENTOK="$(fresh_tree comment_closed)"
+cp "$FIXTURES/comment_closed.md" "$COMMENTOK/docs/scratch.md"
+expect_rc "closed comments remain an exemption" 0 "$COMMENTOK"
+expect_no_out "a closed comment is not reported as unterminated" "unterminated HTML comment"
+
+# ... and the prose after a closed comment is still scanned, so the exemption ends
+# where the comment does.
+COMMENTAFTER="$(fresh_tree comment_closed_then_prose)"
+{
+  printf '# A closed comment does not extend past its closing marker\n\n'
+  printf '<!--\nAn earlier draft said the panel is an AMOLED.\n-->\n\n'
+  printf 'The display is a round AMOLED with 16.7 million colours.\n'
+} > "$COMMENTAFTER/docs/scratch.md"
+expect_rc "prose after a closed comment is still scanned" 1 "$COMMENTAFTER"
+expect_out "the line after the closed comment is named" \
+  "RK-IDENT-VIOLATION: PANEL_AMOLED docs/scratch.md:7"
+
+DANGLING="$(fresh_tree comment_unterminated)"
+cp "$FIXTURES/comment_unterminated.md" "$DANGLING/docs/scratch.md"
+expect_rc "an unterminated comment is a structure failure" 2 "$DANGLING"
+expect_out "the dangling opener is named with its line" \
+  "RK-IDENT-STRUCTURE: docs/scratch.md:7: unterminated HTML comment"
+expect_no_out "a contradiction behind a dangling opener can never report OK" "RK-IDENT-OK"
+
+echo "== rule-level suppressions are observable =="
+
+# A suppressor exists so that truthful qualified prose passes. It must keep doing
+# that -- and every hit it excuses must be visible, or widening one is invisible.
+SUPPRESS="$(fresh_tree suppressed_hits)"
+cp "$FIXTURES/suppressed_hits.md" "$SUPPRESS/docs/scratch.md"
+SUPPREPORT="$WORK/suppressions.json"
+run "$SUPPRESS" --report "$SUPPREPORT"
+if [ "$RUN_RC" -eq 0 ]; then
+  ok "truthful qualified prose still exits 0 (suppressions are not findings)"
+else
+  bad "qualified prose was rejected (rc=$RUN_RC)"
+  printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+fi
+expect_out "a suppression prints an informational token" "RK-IDENT-SUPPRESSED"
+expect_out "the informational token names rule, file and line" \
+  "RK-IDENT-SUPPRESSED: COLOR_DEPTH docs/scratch.md:12"
+expect_out "the summary counter reports the suppression count" "suppressed="
+expect_out "the run still reports OK" "RK-IDENT-OK"
+
+if "$PY" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+rows=d['suppressions']
+mine=[r for r in rows if r['file']=='docs/scratch.md']
+assert len(mine)==4, mine
+for r in mine:
+    assert r['rule'] and r['line']>0 and r['match'] and r['suppressor'], r
+ids={r['rule'] for r in mine}
+assert ids=={'TOUCH_VARIANT','COLOR_DEPTH','ENCODER_BUTTON','BACKLIGHT_DUTY'}, ids
+assert d['token']=='RK-IDENT-OK' and d['exit_code']==0
+" "$SUPPREPORT" 2>/dev/null; then
+  ok "every suppressed hit is in the report with file, line, rule and suppressor"
+else
+  bad "the suppression report was not usable"
+fi
+
+# The counterweight: the same sentences without their qualification must fail, so
+# the suppressor is proven to be the reason they passed rather than a dead rule.
+UNQUALIFIED="$(fresh_tree suppressed_unqualified)"
+{
+  printf '# The same claims without their qualification\n\n'
+  printf 'The fitted touch controller is a CST816D.\n\n'
+  printf 'The display is a 24-bit colour panel.\n\n'
+  printf 'The encoder shaft is pressable.\n'
+  printf 'The backlight starts at 50 %% duty.\n'
+} > "$UNQUALIFIED/docs/scratch.md"
+expect_rc "the same claims unqualified are violations" 1 "$UNQUALIFIED"
+expect_out "unqualified variant claim is named" "RK-IDENT-VIOLATION: TOUCH_VARIANT"
+expect_out "unqualified colour claim is named" "RK-IDENT-VIOLATION: COLOR_DEPTH"
+expect_out "unqualified press claim is named" "RK-IDENT-VIOLATION: ENCODER_BUTTON"
+expect_out "unqualified duty claim is named" "RK-IDENT-VIOLATION: BACKLIGHT_DUTY"
+
+# Removing the observability is a --self-check failure, not a silent narrowing. The
+# recording branch is inverted rather than deleted, so the patch is one line and
+# the rest of the checker is untouched.
+BLIND="$WORK/blind_suppressions.py"
+sed 's|if suppressed is not None:|if suppressed is None:|' "$CHECKER" > "$BLIND"
+if ! cmp -s "$CHECKER" "$BLIND"; then
+  BLIND_OUT="$("$PY" "$BLIND" --root "$REPO" --self-check 2>/dev/null)"
+  BLIND_RC=$?
+  if [ "$BLIND_RC" -eq 4 ] && printf '%s' "$BLIND_OUT" | grep -qF "must stay observable"; then
+    ok "dropping suppression recording fails --self-check (exit 4)"
+  else
+    bad "unobservable suppressions did not fail --self-check (rc=$BLIND_RC)"
+    printf '%s\n' "$BLIND_OUT" | sed 's/^/       | /'
+  fi
+else
+  bad "could not construct the blind-suppression case (patch did not apply)"
+fi
+
+run "$REPO" --self-check
+if printf '%s' "$RUN_OUT" | grep -qE 'suppressed=[0-9]+'; then
+  ok "the repository's own run prints its suppression count"
+else
+  bad "the repository run did not print a suppression count"
+  printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+fi
+
+# The load-bearing case for observability: a *widening* that self-check cannot
+# catch, because it does not swallow the rule's own probe. Adding `touch` to
+# TOUCH_VARIANT's suppressor turns a sentence the unpatched checker rejects into a
+# sentence it accepts. That must not be silent -- the newly excused hit has to
+# appear in the report as a suppression naming the widened suppressor.
+WIDENED="$WORK/widened_unless.py"
+sed 's@unless=r"(datasheet@unless=r"(touch|datasheet@' "$CHECKER" > "$WIDENED"
+WIDETREE="$(fresh_tree widened_suppressor)"
+printf '# Widening probe\n\nThe fitted touch controller is a CST816D on this unit.\n' \
+  > "$WIDETREE/docs/scratch.md"
+if cmp -s "$CHECKER" "$WIDENED"; then
+  bad "could not construct the widened-suppressor case (patch did not apply)"
+else
+  # Direction one: the shipped checker rejects the sentence.
+  expect_rc "the shipped suppressor does not excuse this sentence" 1 "$WIDETREE"
+  # Direction two: the widened copy still passes --self-check (so self-check alone
+  # is not the safety net) and now accepts the sentence...
+  WIDEREPORT="$WORK/widened.json"
+  WIDE_OUT="$("$PY" "$WIDENED" --root "$WIDETREE" --self-check --report "$WIDEREPORT" 2>/dev/null)"
+  WIDE_RC=$?
+  if [ "$WIDE_RC" -eq 0 ]; then
+    ok "a widening that spares its own probe passes --self-check and accepts the sentence"
+  else
+    bad "widened suppressor did not accept the sentence (rc=$WIDE_RC)"
+    printf '%s\n' "$WIDE_OUT" | sed 's/^/       | /'
+  fi
+  # ... but the newly excused hit is reported, so the widening is not silent.
+  if "$PY" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+mine=[r for r in d['suppressions']
+      if r['file']=='docs/scratch.md' and r['rule']=='TOUCH_VARIANT']
+assert len(mine)==1, d['suppressions']
+assert mine[0]['suppressor'].lower()=='touch', mine
+assert mine[0]['match']=='CST816D', mine
+" "$WIDEREPORT" 2>/dev/null; then
+    ok "the widened suppressor's new exemption is visible in the report"
+  else
+    bad "a widened suppressor exempted a line invisibly"
+    printf '%s\n' "$WIDE_OUT" | sed 's/^/       | /'
+  fi
+  if printf '%s' "$WIDE_OUT" | grep -qF "RK-IDENT-SUPPRESSED: TOUCH_VARIANT docs/scratch.md:3"; then
+    ok "the widened suppressor's new exemption is printed in the run output"
+  else
+    bad "the widened exemption was not printed"
+    printf '%s\n' "$WIDE_OUT" | sed 's/^/       | /'
+  fi
+fi
+
+echo "== the canonical record's current facts are scanned =="
+
+# The load-bearing test for the review finding that replaced the file-level
+# exemption: mutate a live row of the identity table in the real board.md.
+LIVEROW="$(fresh_tree live_row)"
+rewrite "$LIVEROW/$BOARD" 's#| Panel technology | \*\*IPS LCD\*\*#| Panel technology | **round AMOLED**#'
+if ! grep -q 'round AMOLED' "$LIVEROW/$BOARD"; then
+  bad "could not mutate the live identity row (pattern did not apply)"
+else
+  expect_rc "an AMOLED row in the live identity table fails" 2 "$LIVEROW"
+  expect_out "the mutated canonical row is named" "RK-IDENT-VIOLATION: PANEL_AMOLED $BOARD"
+fi
+
+# ... and the same for a repository-observed row, so the proof is not specific to
+# one table.
+LIVEROW2="$(fresh_tree live_row_r)"
+rewrite "$LIVEROW2/$BOARD" 's#Initial backlight duty is#Initial backlight duty is 50 % duty, formerly#'
+if ! grep -qF '50 % duty, formerly' "$LIVEROW2/$BOARD"; then
+  bad "could not mutate the live R row (pattern did not apply)"
+else
+  expect_rc "a stale 50 % duty claim in a live R row fails" 1 "$LIVEROW2"
+  expect_out "the mutated R row is named" "RK-IDENT-VIOLATION: BACKLIGHT_DUTY $BOARD"
+fi
+
+echo "== the section allowance is section-scoped, not file-scoped =="
+
+# Moving the historical table's wording out of its allowed section must fail,
+# even though it stays in the same file.
+MOVED="$(fresh_tree moved_history)"
+{
+  cat "$BASE/docs/esp/hw-reference/HARDWARE_PINS.md"
+  printf '\n## Notes\n\nPanel is a round AMOLED, as an earlier draft said.\n'
+} > "$MOVED/docs/esp/hw-reference/HARDWARE_PINS.md"
+expect_rc "the same historical wording in a non-allowed file fails" 1 "$MOVED"
+
+RENAMED="$(fresh_tree renamed_section)"
+rewrite "$RENAMED/$BOARD" 's/^## Historical claims, now superseded$/## Historical notes/'
+expect_rc "renaming the allowed section fails" 2 "$RENAMED"
+expect_out "the missing allowed section is named" "missing required section"
+
+# An allowance over a section that no longer restates anything is a hole, so it is
+# reported rather than left in place.
+EMPTIED="$(fresh_tree emptied_section)"
+"$PY" - "$EMPTIED/$ADR" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+start = text.index("## Context")
+end = text.index("## Decision")
+# Keep the heading, replace everything it covers with prose that restates nothing
+# guarded. The allowance over this section then has no work left to do.
+text = text[:start] + "## Context\n\nNothing guarded is restated here any more.\n\n" + text[end:]
+open(path, "w", encoding="utf-8").write(text)
+PY
+run "$EMPTIED"
+if [ "$RUN_RC" -eq 2 ] && printf '%s' "$RUN_OUT" | grep -qF "the allowance is dead"; then
+  ok "an allowed section that restates nothing is reported as a dead allowance (exit 2)"
+else
+  bad "dead section allowance was not reported (rc=$RUN_RC)"
+  printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+fi
+
+# Section state is read from the comment-stripped text, because a heading is only a
+# heading if a reader can see it. `section` is what grants a SECTION_ALLOWANCES
+# exemption, so invisible text must not be able to move it in either direction.
+#
+# Direction one -- it must not CLEAR the allowed section. This is the reachable
+# defect: a line that closes a multi-line comment is still scanned for prose after
+# the closing marker, so its *raw* text reaches the heading matcher. A `#` line
+# ending in `-->` therefore used to reset `section` to None, silently revoking the
+# historical allowance for every superseded row below it. Reading the visible text
+# instead leaves the allowance intact, so this case must be green.
+COMMENTRESET="$(fresh_tree comment_heading_reset)"
+"$PY" - "$COMMENTRESET/$BOARD" <<'PY'
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+old = "## Historical claims, now superseded\n"
+if text.count(old) != 1:
+    sys.exit(1)
+# The `#` line is the comment's *closing* line, not an interior one: interior lines
+# are skipped wholesale, so an interior heading would not exercise the matcher.
+hidden = "<!-- an earlier draft's heading, kept only as a note\n# a heading that exists only inside this comment -->\n"
+open(path, "w", encoding="utf-8").write(text.replace(old, old + "\n" + hidden, 1))
+PY
+if ! grep -qF '# a heading that exists only inside this comment -->' "$COMMENTRESET/$BOARD"; then
+  bad "could not insert the comment-closing heading line (patch did not apply)"
+else
+  expect_rc "a '#' line inside an HTML comment does not clear the allowed section" \
+    0 "$COMMENTRESET"
+  expect_out "the section allowance survives an invisible heading" "RK-IDENT-OK"
+  expect_no_out "no superseded row is reported once the allowance is intact" \
+    "RK-IDENT-VIOLATION"
+fi
+
+# Direction two -- it must not GRANT one either. Hiding the real heading inside a
+# comment removes the exemption: the rows it used to cover become ordinary
+# current-fact prose and are reported, and the allowance that no longer suppresses
+# anything is named. This holds however the heading is hidden, so it is a contract
+# pin rather than a discriminator on any one code path -- its job is to make any
+# future attempt to read section state from invisible text fail here.
+COMMENTHEAD="$(fresh_tree comment_heading_hidden)"
+"$PY" - "$COMMENTHEAD/$BOARD" <<'PY'
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+old = "## Historical claims, now superseded\n"
+if text.count(old) != 1:
+    sys.exit(1)
+open(path, "w", encoding="utf-8").write(
+    text.replace(old, "<!-- hidden heading\n" + old.rstrip("\n") + " -->\n", 1)
+)
+PY
+# The heading text is deliberately still present -- it is now inside a comment -- so
+# the guard asserts the wrapper, not the absence of the line.
+if ! grep -qF '## Historical claims, now superseded -->' "$COMMENTHEAD/$BOARD"; then
+  bad "could not hide the historical heading inside a comment (patch did not apply)"
+else
+  run "$COMMENTHEAD"
+  if [ "$RUN_RC" -ne 0 ] \
+     && printf '%s' "$RUN_OUT" | grep -qF "RK-IDENT-VIOLATION: PANEL_AMOLED $BOARD"; then
+    ok "a heading visible only inside a comment grants no exemption (exit $RUN_RC)"
+  else
+    bad "a commented historical heading still granted the section allowance (rc=$RUN_RC)"
+    printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+  fi
+  expect_no_out "a commented historical heading can never report OK" "RK-IDENT-OK"
+fi
+
+echo "== the other-target line allowance works, and only just far enough =="
+
+MARKED="$(fresh_tree other_marked)"
+cp "$FIXTURES/other_target_marked.md" "$MARKED/docs/scratch.md"
+expect_rc "truthful other-board prose passes with the marker" 0 "$MARKED"
+
+SAME_LINE="$(fresh_tree other_marker_same_line)"
+{
+  printf '# Marker must stand alone\n\n'
+  printf 'The shipping round knob has an AMOLED panel. <!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-AMOLED-1.91" reason="the following line truthfully describes a separate sibling product" -->\n'
+  printf 'The ESP32-S3-AMOLED-1.91 is a separate AMOLED product.\n'
+} > "$SAME_LINE/docs/scratch.md"
+expect_rc "prose before an otherwise valid marker on the same line is rejected" 1 "$SAME_LINE"
+expect_out "same-line marker misuse is named" "RK-IDENT-MARKER-ABUSE"
+expect_out "prose before the same-line marker is still scanned" "RK-IDENT-VIOLATION: PANEL_AMOLED docs/scratch.md:3"
+
+UNMARKED="$(fresh_tree other_unmarked)"
+cp "$FIXTURES/other_target_unmarked.md" "$UNMARKED/docs/scratch.md"
+expect_rc "the same prose without the marker fails" 1 "$UNMARKED"
+expect_out "unmarked other-board prose names PANEL_AMOLED" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+
+SECOND="$(fresh_tree other_second_line)"
+cp "$FIXTURES/other_target_second_line.md" "$SECOND/docs/scratch.md"
+expect_rc "one marker cannot cover a second line" 1 "$SECOND"
+expect_out "the uncovered second line is reported" "docs/scratch.md:8"
+expect_no_out "the covered first line is not reported" "docs/scratch.md:7"
+
+UNRELATED="$(fresh_tree other_unrelated)"
+cp "$FIXTURES/other_target_unrelated_line.md" "$UNRELATED/docs/scratch.md"
+expect_rc "a marker cannot silence a line that never mentions the declared target" 1 "$UNRELATED"
+expect_out "the mismatched target is reported as abuse" "RK-IDENT-MARKER-ABUSE"
+expect_out "the abuse message names the target mismatch" "does not mention it"
+expect_out "the contradiction it tried to hide is still reported" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+
+SHIP="$(fresh_tree other_shipping)"
+cp "$FIXTURES/other_target_shipping.md" "$SHIP/docs/scratch.md"
+expect_rc "a marker naming the shipping target is rejected" 1 "$SHIP"
+expect_out "shipping-target abuse is named" "names the shipping target"
+
+NOREASON="$(fresh_tree other_no_reason)"
+cp "$FIXTURES/other_target_no_reason.md" "$NOREASON/docs/scratch.md"
+expect_rc "a marker with a token reason is rejected" 1 "$NOREASON"
+expect_out "short reason is named" "reason is shorter than"
+
+STACKED="$(fresh_tree other_stacked)"
+{
+  printf '# Stacked markers\n\n'
+  printf '<!-- rk-ident-allow-next-line: PANEL_AMOLED target="ESP32-S3-AMOLED-1.91" reason="first of two stacked markers, which is not a supported form at all" -->\n'
+  printf '<!-- rk-ident-allow-next-line: COLOR_DEPTH target="ESP32-S3-AMOLED-1.91" reason="second of two stacked markers, which is not a supported form at all" -->\n'
+  printf 'The ESP32-S3-AMOLED-1.91 has an AMOLED panel and 16.7 million colours.\n'
+} > "$STACKED/docs/scratch.md"
+expect_rc "stacked markers are rejected" 1 "$STACKED"
+expect_out "stacking is named" "cannot be stacked"
+
+MALFORMED="$(fresh_tree other_malformed)"
+{
+  printf '# Malformed marker\n\n'
+  printf '<!-- rk-ident-allow-next-line: PANEL_AMOLED -->\n'
+  printf 'The ESP32-S3-AMOLED-1.91 has an AMOLED panel.\n'
+} > "$MALFORMED/docs/scratch.md"
+expect_rc "a marker missing target and reason is rejected" 1 "$MALFORMED"
+expect_out "malformed marker is named" "malformed allowance"
+
+UNKNOWNRULE="$(fresh_tree other_unknown_rule)"
+{
+  printf '# Unknown rule id\n\n'
+  printf '<!-- rk-ident-allow-next-line: NOT_A_RULE target="ESP32-S3-AMOLED-1.91" reason="naming a rule that does not exist, which must not silently pass review" -->\n'
+  printf 'The ESP32-S3-AMOLED-1.91 has an AMOLED panel.\n'
+} > "$UNKNOWNRULE/docs/scratch.md"
+expect_rc "a marker naming an unknown rule is rejected" 1 "$UNKNOWNRULE"
+expect_out "unknown rule id is named" "unknown rule"
+
+IDLE="$(fresh_tree other_idle)"
+{
+  printf '# A marker that suppresses nothing\n\n'
+  printf '<!-- rk-ident-allow-next-line: PANEL_AMOLED target="T-Display-S3" reason="left behind after the sentence it covered was rewritten to say nothing guarded" -->\n'
+  printf 'The T-Display-S3 is a different board with a different panel entirely.\n'
+} > "$IDLE/docs/scratch.md"
+expect_rc "an allowance that suppresses nothing is a structure failure" 2 "$IDLE"
+expect_out "the idle allowance is named" "suppresses nothing"
+
+echo "== the retired file-level marker cannot come back =="
+
+RETIRED="$(fresh_tree retired_marker)"
+cp "$FIXTURES/retired_marker.md" "$RETIRED/docs/scratch.md"
+expect_rc "the retired file-level marker is rejected" 1 "$RETIRED"
+expect_out "retired marker is named" "retired rk-ident-allow-file marker"
+expect_out "the contradiction it tried to hide is still reported" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+
+# Prose *about* the marker is not a use of it: the decision record explains both
+# markers in running text and must stay clean.
+run "$BASE"
+expect_no_out "prose that merely names the markers is not reported" "RK-IDENT-MARKER-ABUSE"
+
+echo "== absence never reads as satisfied =="
+
+expect_rc "an empty tree fails rather than passing vacuously" 3 "$WORK/empty_tree_does_not_exist"
+expect_out "missing root is named" "RK-IDENT-MISSING"
+
+EMPTY="$WORK/empty"
+mkdir -p "$EMPTY"
+expect_rc "a tree with no Markdown at all fails" 3 "$EMPTY"
+expect_out "empty tree reports MISSING" "RK-IDENT-MISSING"
+
+NOCANON="$(fresh_tree no_canonical)"
+rm -f "$NOCANON/$BOARD"
+expect_rc "deleting the canonical record fails" 3 "$NOCANON"
+expect_out "deleted canonical record is named" "canonical record absent"
+
+NOADR="$(fresh_tree no_adr)"
+rm -f "$NOADR/$ADR"
+expect_rc "deleting the decision record fails" 3 "$NOADR"
+expect_out "deleted decision record is named" "decision record absent"
+
+echo "== canonical structure is enforced =="
+
+GUTTED="$(fresh_tree gutted)"
+grep -v '^## Still requires physical inspection' "$BASE/$BOARD" > "$GUTTED/$BOARD.tmp"
+mv "$GUTTED/$BOARD.tmp" "$GUTTED/$BOARD"
+expect_rc "removing a required section fails" 2 "$GUTTED"
+expect_out "removed section is named" "missing required section"
+
+REORDERED="$(fresh_tree reordered)"
+"$PY" - "$BASE/$BOARD" "$REORDERED/$BOARD" <<'PY'
+import sys
+src, dst = sys.argv[1], sys.argv[2]
+text = open(src, encoding="utf-8").read()
+a, b = "## Historical claims, now superseded", "## Still requires physical inspection"
+text = text.replace(a, "@@TMP@@").replace(b, a).replace("@@TMP@@", b)
+open(dst, "w", encoding="utf-8").write(text)
+PY
+run "$REORDERED"
+if [ "$RUN_RC" -ne 0 ]; then
+  ok "swapping two required sections fails (exit $RUN_RC)"
+else
+  bad "reordered canonical sections were accepted"
+fi
+
+DEVALUED="$(fresh_tree devalued)"
+rewrite "$DEVALUED/$BOARD" 's/ST77916/REDACTED/g'
+expect_rc "dropping a corrected value fails" 2 "$DEVALUED"
+expect_out "dropped value is named" "corrected value"
+
+DUTYGONE="$(fresh_tree duty_value_gone)"
+rewrite "$DUTYGONE/$BOARD" 's/CONFIG_RK_BACKLIGHT_NORMAL/SOME_OTHER_SYMBOL/g'
+expect_rc "dropping the backlight-duty symbol fails" 2 "$DUTYGONE"
+expect_out "dropped duty symbol is named" "CONFIG_RK_BACKLIGHT_NORMAL"
+
+HISTORYONLY="$(fresh_tree corrected_value_history_only)"
+"$PY" - "$HISTORYONLY/$BOARD" <<'PY'
+import sys
+
+path = sys.argv[1]
+lines = open(path, encoding="utf-8").readlines()
+section = None
+out = []
+for line in lines:
+    if line.startswith("## "):
+        section = line.strip()
+    if section != "## Historical claims, now superseded":
+        line = line.replace("262 K", "REDACTED").replace("262K", "REDACTED")
+    out.append(line)
+open(path, "w", encoding="utf-8").writelines(out)
+PY
+expect_rc "a corrected value found only in the Historical table fails" 2 "$HISTORYONLY"
+expect_out "history-only corrected value is named" "corrected value '262'"
+
+AFTERFENCE="$(fresh_tree corrected_value_after_fenced_comments)"
+"$PY" - "$AFTERFENCE/$BOARD" <<'PY'
+import sys
+
+path = sys.argv[1]
+lines = open(path, encoding="utf-8").readlines()
+keep = False
+out = []
+for line in lines:
+    if line.startswith("`esp_lcd_sh8601` 2.0.1 and 2.0.1~1 differ"):
+        keep = True
+    if not keep:
+        line = line.replace("esp_lcd_sh8601", "REDACTED_DRIVER")
+    out.append(line)
+open(path, "w", encoding="utf-8").writelines(out)
+PY
+expect_rc "a corrected value after hash-prefixed lines in a fence remains live" 0 "$AFTERFENCE"
+
+DECLASSED="$(fresh_tree declassed)"
+rewrite "$DECLASSED/$BOARD" 's/Physically unverified/Somewhat unclear/g'
+expect_rc "dropping a provenance class fails" 2 "$DECLASSED"
+expect_out "dropped class is named" "provenance class"
+
+UNLINKED="$(fresh_tree unlinked)"
+rewrite "$UNLINKED/docs/esp/DISPLAY.md" 's|(hw-reference/board.md|(hw-reference/nowhere.md|g'
+expect_rc "removing a canonical link fails" 2 "$UNLINKED"
+expect_out "unlinked document is named" "no Markdown link to board.md"
+
+DEADLINK="$(fresh_tree dead_canonical_link)"
+rewrite "$DEADLINK/README.md" \
+  's|(docs/esp/hw-reference/board.md)|(docs/esp/hw-reference/nonexistent/board.md)|g'
+if ! grep -qF 'nonexistent/board.md' "$DEADLINK/README.md"; then
+  bad "could not replace the root README canonical target (pattern did not apply)"
+else
+  expect_rc "a link-shaped string ending in board.md must resolve to the canonical file" \
+    2 "$DEADLINK"
+  expect_out "the dead canonical target names the root README" \
+    "README.md: no Markdown link to board.md"
+fi
+
+echo "== source anchors keep the repository-observed citations fresh =="
+
+# Prose rules cannot notice when the source a repository-observed row was read from
+# moves out from under it: the documentation stays word-for-word correct-looking
+# while its citation rots. These cases pin both discriminating directions -- one
+# mutated token, one deleted file -- and pin the wording, because an anchor claims
+# citation freshness and must not be read as proof the fact is true or false.
+
+ANCHOR_LIST="$("$PY" "$CHECKER" --list-anchors 2>/dev/null)"
+ANCHOR_LIST_RC=$?
+if [ "$ANCHOR_LIST_RC" -eq 0 ] && printf '%s' "$ANCHOR_LIST" | grep -q "$(printf 'BACKLIGHT_GPIO47\tidf_app/main/platform_display_idf.c')"; then
+  ok "--list-anchors exits 0 and prints id and path"
+else
+  bad "--list-anchors failed (rc=$ANCHOR_LIST_RC)"
+  printf '%s\n' "$ANCHOR_LIST" | sed 's/^/       | /'
+fi
+
+ANCHOR_N="$(printf '%s\n' "$ANCHOR_LIST" | grep -c .)"
+if [ "$ANCHOR_N" -ge 13 ]; then
+  ok "the anchor table is populated ($ANCHOR_N anchors)"
+else
+  bad "expected at least 13 source anchors, found $ANCHOR_N"
+fi
+
+# A floor, not an equality: the anchor table covers a subset of the canonical
+# record's repository-observed rows, and no assertion here may imply otherwise.
+# The rows deliberately left unanchored -- negative, uniqueness, derived-count and
+# physical -- are named in the checker's docstring and in the ADR.
+for want in QSPI_PINS PANEL_INIT_ARRAY ZONE_PICKER_TOUCH_ENTRY ZONE_PICKER_HANDLER; do
+  if printf '%s\n' "$ANCHOR_LIST" | cut -f1 | grep -qxF "$want"; then
+    ok "the positively quotable row $want is anchored"
+  else
+    bad "expected a source anchor named $want"
+  fi
+done
+
+# A tree carrying the cited sources is clean, and says so in the counters. This is
+# the control for the two failure cases below.
+FRESH="$(fresh_tree anchors_fresh)"
+expect_rc "a tree carrying every cited source file is accepted" 0 "$FRESH"
+expect_out "the summary counts every anchor as fresh" "anchors_fresh=$ANCHOR_N/$ANCHOR_N"
+expect_no_out "a fresh anchor is not reported" "source anchor"
+
+# Direction one: mutate exactly one expected token. The duty assignment is the
+# load-bearing one -- it is the value that corrected the stale 50 % comment -- and
+# changing it leaves every other anchor in this file intact, so the finding must
+# name one anchor and one token.
+MUTATED="$(fresh_tree anchor_token_mutated)"
+rewrite "$MUTATED/idf_app/main/platform_display_idf.c" \
+  's/\.duty = CONFIG_RK_BACKLIGHT_NORMAL/.duty = 128/'
+if ! grep -q '\.duty = 128' "$MUTATED/idf_app/main/platform_display_idf.c"; then
+  bad "could not mutate the duty assignment (pattern did not apply)"
+else
+  expect_rc "a mutated anchor token is a structure failure" 2 "$MUTATED"
+  expect_out "the stale citation names its anchor" \
+    "RK-IDENT-STRUCTURE: source anchor BACKLIGHT_DUTY_ASSIGNMENT"
+  expect_out "the stale citation names the file" "idf_app/main/platform_display_idf.c"
+  expect_out "the stale citation names the missing token" \
+    "'.duty = CONFIG_RK_BACKLIGHT_NORMAL,'"
+  expect_out "the finding says a stale citation is not a false claim" \
+    "not that the claim is false"
+  expect_out "the finding says anchors do not check cited line numbers" \
+    "an anchor checks text, never the line numbers the row cites"
+  expect_out "the counter shows the shortfall" "anchors_fresh=$((ANCHOR_N - 1))/$ANCHOR_N"
+  expect_no_out "a stale citation can never report OK" "RK-IDENT-OK"
+  # Only the one anchor is affected: a whole-file panic would make the finding
+  # useless for locating the drift.
+  expect_no_out "the untouched backlight-pin anchor is not reported" \
+    "source anchor BACKLIGHT_GPIO47"
+fi
+
+# Direction two: delete a cited file outright. This is a STRUCTURE finding, not
+# MISSING: MISSING is reserved for the documents the guard itself requires.
+NOSOURCE="$(fresh_tree anchor_file_removed)"
+rm -f "$NOSOURCE/idf_app/main/idf_component.yml"
+expect_rc "a deleted cited source file is a structure failure" 2 "$NOSOURCE"
+expect_out "the absent file names its anchor" \
+  "RK-IDENT-STRUCTURE: source anchor DRIVER_VERSION_UNPINNED"
+expect_out "the absent file is named" "cited file idf_app/main/idf_component.yml is absent"
+expect_out "the absent-file finding is worded as freshness, not falsity" \
+  "not evidence the claim is false"
+expect_out "the absent-file finding also disclaims line-number checking" \
+  "never the line numbers the row cites"
+expect_no_out "a deleted cited source can never report OK" "RK-IDENT-OK"
+
+# Relationship, not fragments. The failure mode a split token hides is a file in
+# which both halves are still present and no longer describe each other, so this
+# renames the encoder A pin and asserts the anchor notices. A pair of tokens
+# `#define ENCODER_GPIO_A` + `GPIO_NUM_8` would not: `GPIO_NUM_8` survives in the
+# renamed line, and `#define ENCODER_GPIO_A` survives too.
+SPLITCASE="$(fresh_tree anchor_relationship)"
+rewrite "$SPLITCASE/idf_app/main/platform_input_idf.c" \
+  's/#define ENCODER_GPIO_A    GPIO_NUM_8/#define ENCODER_GPIO_A    GPIO_NUM_9  \/\/ was GPIO_NUM_8/'
+if ! grep -q 'ENCODER_GPIO_A    GPIO_NUM_9' "$SPLITCASE/idf_app/main/platform_input_idf.c"; then
+  bad "could not repoint the encoder A pin (pattern did not apply)"
+elif ! grep -q 'GPIO_NUM_8' "$SPLITCASE/idf_app/main/platform_input_idf.c"; then
+  bad "the repointed file no longer mentions GPIO_NUM_8, so it does not test a split token"
+else
+  expect_rc "a broken pin relationship is a structure failure even though both halves remain" \
+    2 "$SPLITCASE"
+  expect_out "the broken relationship names the encoder anchor" \
+    "RK-IDENT-STRUCTURE: source anchor ENCODER_PINS"
+  expect_out "the broken relationship names the whole-line token" \
+    "'#define ENCODER_GPIO_A GPIO_NUM_8'"
+fi
+
+# Word-boundary guards: a token must not be satisfied by a longer literal that
+# merely starts with it. Widening 0x15 to 0x155 must be caught.
+PREFIXCASE="$(fresh_tree anchor_prefix)"
+rewrite "$PREFIXCASE/idf_app/components/i2c_bsp/settings.h" \
+  's/#define TOUCH_ADDR 0x15$/#define TOUCH_ADDR 0x155/'
+if ! grep -q 'TOUCH_ADDR 0x155' "$PREFIXCASE/idf_app/components/i2c_bsp/settings.h"; then
+  bad "could not widen the touch address (pattern did not apply)"
+else
+  expect_rc "a token does not match a longer literal that starts with it" 2 "$PREFIXCASE"
+  expect_out "the widened literal names the touch-address anchor" \
+    "RK-IDENT-STRUCTURE: source anchor TOUCH_I2C_ADDRESS"
+fi
+
+# Whitespace insensitivity is the other half of the same bargain: pinning a whole
+# line is only sane if realignment does not break it.
+REALIGNED="$(fresh_tree anchor_realigned)"
+rewrite "$REALIGNED/idf_app/main/platform_input_idf.c" \
+  's/#define ENCODER_GPIO_A    GPIO_NUM_8/#define ENCODER_GPIO_A GPIO_NUM_8/'
+if ! grep -q '#define ENCODER_GPIO_A GPIO_NUM_8' "$REALIGNED/idf_app/main/platform_input_idf.c"; then
+  bad "could not realign the encoder A define (pattern did not apply)"
+else
+  expect_rc "realigning an anchored line does not break its anchor" 0 "$REALIGNED"
+  expect_out "the realigned tree still counts every anchor fresh" "anchors_fresh=$ANCHOR_N/$ANCHOR_N"
+fi
+
+# ... and "whitespace-insensitive" has to mean the gap may *close* at a punctuation
+# boundary, not merely shrink. The QSPI_PINS token was written from a wrapped call
+# site (`SH8601_PANEL_IO_QSPI_CONFIG(` then `PIN_NUM_LCD_CS,` on the next line), so
+# it carries a space after `(`. Unwrapping the argument list changes no fact, and
+# must not report a stale citation. Both one-line spellings are pinned so the
+# distinction cannot silently regress to a mandatory space.
+for gap in ' ' ''; do
+  [ -n "$gap" ] && form=spaced || form=unspaced
+  QSPIFORM="$(fresh_tree "anchor_qspi_$form")"
+  QSPIWANT="SH8601_PANEL_IO_QSPI_CONFIG(${gap}PIN_NUM_LCD_CS,"
+  "$PY" - "$QSPIFORM/idf_app/main/platform_display_idf.c" "$QSPIWANT" <<'PY'
+import re
+import sys
+
+path, want = sys.argv[1], sys.argv[2]
+text = open(path, encoding="utf-8").read()
+collapsed, count = re.subn(
+    r"SH8601_PANEL_IO_QSPI_CONFIG\(\s+PIN_NUM_LCD_CS,", want, text, count=1
+)
+if count != 1:
+    sys.exit(1)
+open(path, "w", encoding="utf-8").write(collapsed)
+PY
+  if ! grep -qF "$QSPIWANT" "$QSPIFORM/idf_app/main/platform_display_idf.c"; then
+    bad "could not unwrap the QSPI macro call to its $form one-line form"
+  else
+    expect_rc "the $form one-line QSPI macro call keeps its anchor fresh" 0 "$QSPIFORM"
+    expect_out "the $form QSPI form counts every anchor fresh" "anchors_fresh=$ANCHOR_N/$ANCHOR_N"
+  fi
+done
+
+# The other side of that relaxation: whitespace between two *word* lexemes stays
+# mandatory, or a token would be satisfied by two identifiers fused into one.
+FUSED="$(fresh_tree anchor_word_fused)"
+rewrite "$FUSED/idf_app/main/platform_display_idf.c" \
+  's/#define PIN_NUM_BK_LIGHT /#definePIN_NUM_BK_LIGHT /'
+if ! grep -qF '#definePIN_NUM_BK_LIGHT' "$FUSED/idf_app/main/platform_display_idf.c"; then
+  bad "could not fuse the backlight define (pattern did not apply)"
+else
+  expect_rc "two word lexemes fused together do not satisfy the token" 2 "$FUSED"
+  expect_out "the fused define names the backlight anchor" \
+    "RK-IDENT-STRUCTURE: source anchor BACKLIGHT_GPIO47"
+  expect_out "the fused define names the missing token" \
+    "'#define PIN_NUM_BK_LIGHT ((gpio_num_t)47)'"
+fi
+
+# Pin the negative capability too. Moving source text without changing it leaves
+# every token fresh while the canonical record's literal :62 citation goes stale.
+# This test must stay green: it demonstrates the known limit rather than pretending
+# to solve it, and makes any future claim that anchors validate line numbers fail
+# against executable evidence.
+LINEMOVED="$(fresh_tree anchor_line_moved)"
+DISPLAY_SOURCE="$LINEMOVED/idf_app/main/platform_display_idf.c"
+ORIGINAL_PIN_LINE="$(grep -nF '#define PIN_NUM_BK_LIGHT' "$DISPLAY_SOURCE" | head -1 | cut -d: -f1)"
+{
+  for n in $(seq 1 20); do
+    printf '// line-movement fixture %s\n' "$n"
+  done
+  cat "$DISPLAY_SOURCE"
+} > "$DISPLAY_SOURCE.shifted"
+mv "$DISPLAY_SOURCE.shifted" "$DISPLAY_SOURCE"
+MOVED_PIN_LINE="$(grep -nF '#define PIN_NUM_BK_LIGHT' "$DISPLAY_SOURCE" | head -1 | cut -d: -f1)"
+# Empty means the define was renamed or removed. Default both to 0 so the `-eq`
+# arithmetic below cannot emit a shell error before falling through to `bad`, and
+# require the original lookup to have found something at all.
+: "${ORIGINAL_PIN_LINE:=0}"
+: "${MOVED_PIN_LINE:=0}"
+if [ "$ORIGINAL_PIN_LINE" -gt 0 ] \
+   && [ "$MOVED_PIN_LINE" -eq $((ORIGINAL_PIN_LINE + 20)) ] \
+   && grep -qF 'idf_app/main/platform_display_idf.c:62' "$LINEMOVED/$BOARD"; then
+  ok "the line-movement fixture leaves the canonical :62 citation stale by 20 lines"
+else
+  bad "the line-movement fixture did not create the documented stale-citation condition"
+fi
+expect_rc "pure line movement remains outside source-anchor scope" 0 "$LINEMOVED"
+expect_out "line movement leaves every table anchor fresh" \
+  "anchors_fresh=$ANCHOR_N/$ANCHOR_N"
+
+# The inventory is in the report, not only the failures, so a reader can see which
+# citations were checked at all.
+ANCHORREPORT="$WORK/anchors.json"
+run "$MUTATED" --report "$ANCHORREPORT"
+if "$PY" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+rows=d['source_anchors']
+assert len(rows)>=13, rows
+byid={r['id']: r for r in rows}
+bad_=byid['BACKLIGHT_DUTY_ASSIGNMENT']
+assert bad_['status']=='missing-token', bad_
+assert bad_['missing']==['.duty = CONFIG_RK_BACKLIGHT_NORMAL,'], bad_
+assert bad_['path']=='idf_app/main/platform_display_idf.c', bad_
+assert bad_['claim'], bad_
+assert byid['BACKLIGHT_GPIO47']['status']=='ok', byid['BACKLIGHT_GPIO47']
+assert all(r['tokens'] for r in rows), rows
+# The report must carry the checker's own statement of what the count means, so a
+# reader of the JSON or the step summary cannot take N/N for coverage of the R rows
+# or for a check on the cited line numbers.
+scope=d['source_anchor_scope']
+assert 'NOT that every' in scope, scope
+assert 'line numbers' in scope, scope
+# The failure is reported once, as a structure failure, and gates the exit code.
+assert d['token']=='RK-IDENT-STRUCTURE' and d['exit_code']==2
+assert sum(1 for s in d['structure_failures'] if 'source anchor' in s)==1, d['structure_failures']
+" "$ANCHORREPORT" 2>/dev/null; then
+  ok "the report carries every anchor with its status, and the failure exactly once"
+else
+  bad "the source-anchor report was not usable"
+  printf '%s\n' "$RUN_OUT" | sed 's/^/       | /'
+fi
+
+# The renderer counts anchors, labels the count as a table size rather than as
+# coverage, carries the checker's scope note, and does not invent a second finding
+# section.
+sum_anchor_out="$("$PY" "$REPO/scripts/summarize_docs_identity.py" --report "$ANCHORREPORT" 2>/dev/null)"
+if printf '%s' "$sum_anchor_out" | grep -qF "| source anchors in table | $ANCHOR_N |" \
+   && printf '%s' "$sum_anchor_out" | grep -qF "source anchor BACKLIGHT_DUTY_ASSIGNMENT" \
+   && ! printf '%s' "$sum_anchor_out" | grep -qF "### source anchors"; then
+  ok "the summary counts anchors and renders the stale one under structure failures"
+else
+  bad "the summary did not render the source-anchor state correctly"
+  printf '%s\n' "$sum_anchor_out" | sed 's/^/       | /'
+fi
+if printf '%s' "$sum_anchor_out" | grep -qF "NOT that every" \
+   && printf '%s' "$sum_anchor_out" | grep -qF "line numbers"; then
+  ok "the summary states that the anchor count is not coverage and excludes line numbers"
+else
+  bad "the summary rendered an anchor count with no scope note"
+  printf '%s\n' "$sum_anchor_out" | sed 's/^/       | /'
+fi
+# A report predating the field must still render, without inventing a claim.
+NOSCOPE="$WORK/anchors_noscope.json"
+"$PY" -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+d.pop("source_anchor_scope", None)
+json.dump(d, open(sys.argv[2], "w"))
+' "$ANCHORREPORT" "$NOSCOPE" 2>/dev/null
+sum_noscope_out="$("$PY" "$REPO/scripts/summarize_docs_identity.py" --report "$NOSCOPE" 2>/dev/null)"
+sum_noscope_rc=$?
+if [ "$sum_noscope_rc" -eq 0 ] \
+   && printf '%s' "$sum_noscope_out" | grep -qF "| source anchors in table | $ANCHOR_N |" \
+   && ! printf '%s' "$sum_noscope_out" | grep -qF "NOT that every"; then
+  ok "a report without the scope note still renders, and claims nothing extra"
+else
+  bad "the renderer mishandled a report with no source_anchor_scope (rc=$sum_noscope_rc)"
+  printf '%s\n' "$sum_noscope_out" | sed 's/^/       | /'
+fi
+
+# An anchor with no expected tokens could never fail, which is the way this layer
+# rots into decoration. Self-check refuses it.
+TOKENLESS="$WORK/tokenless_anchor.py"
+sed 's|(".duty = CONFIG_RK_BACKLIGHT_NORMAL,",)|()|' "$CHECKER" > "$TOKENLESS"
+if ! cmp -s "$CHECKER" "$TOKENLESS"; then
+  TOK_OUT="$("$PY" "$TOKENLESS" --root "$REPO" --self-check 2>/dev/null)"
+  TOK_RC=$?
+  if [ "$TOK_RC" -eq 4 ] && printf '%s' "$TOK_OUT" | grep -qF "asserts no tokens"; then
+    ok "an anchor with no expected tokens fails --self-check (exit 4)"
+  else
+    bad "a tokenless anchor did not fail --self-check (rc=$TOK_RC)"
+    printf '%s\n' "$TOK_OUT" | sed 's/^/       | /'
+  fi
+else
+  bad "could not construct the tokenless-anchor case (patch did not apply)"
+fi
+
+# A bare identifier or literal as a token is the split-token regression: it looks
+# like an assertion and cannot state the relationship it is cited for. Self-check
+# refuses it, so the table cannot quietly slide back to fragments.
+BARETOKEN="$WORK/bare_token_anchor.py"
+sed 's|(".duty = CONFIG_RK_BACKLIGHT_NORMAL,",)|("CONFIG_RK_BACKLIGHT_NORMAL",)|' \
+  "$CHECKER" > "$BARETOKEN"
+if ! cmp -s "$CHECKER" "$BARETOKEN"; then
+  BARE_OUT="$("$PY" "$BARETOKEN" --root "$REPO" --self-check 2>/dev/null)"
+  BARE_RC=$?
+  if [ "$BARE_RC" -eq 4 ] \
+     && printf '%s' "$BARE_OUT" | grep -qF "is a bare identifier or literal"; then
+    ok "a bare-identifier token fails --self-check (exit 4)"
+  else
+    bad "a bare-identifier token did not fail --self-check (rc=$BARE_RC)"
+    printf '%s\n' "$BARE_OUT" | sed 's/^/       | /'
+  fi
+else
+  bad "could not construct the bare-token case (patch did not apply)"
+fi
+
+echo "== the suppression fingerprint is pinned =="
+
+# A suppression is truthful qualified prose the guard deliberately chose *not* to
+# report -- it never changes the exit code, and a run whose only findings are
+# suppressions is still green. That is exactly why the set needs pinning here:
+# widening a suppressor is invisible in an exit code and shows up only as a longer
+# list nobody diffs. Pinning it turns a change into review friction, which is the
+# intended cost, and is NOT a claim that any of these lines is untruthful.
+BASEREPORT="$WORK/baseline_suppressions.json"
+run "$REPO" --self-check --report "$BASEREPORT"
+ACTUAL_SUPPRESSION_FINGERPRINT="$(fingerprint "$BASEREPORT")"
+if [ -z "$ACTUAL_SUPPRESSION_FINGERPRINT" ]; then
+  bad "could not read the suppression set from the report"
+elif [ "$ACTUAL_SUPPRESSION_FINGERPRINT" = "$EXPECTED_SUPPRESSION_FINGERPRINT" ]; then
+  ok "the repository's suppression set matches the pinned fingerprint"
+else
+  bad "the suppression set no longer matches the pinned fingerprint.
+       This is REVIEW FRICTION, not a runtime failure: a suppression is truthful
+       qualified prose the guard chose not to report, and the checker itself still
+       exits 0 on a run whose only findings are suppressions. Nothing here says any
+       line is untruthful -- it says a different set of lines is now being excused.
+
+       Below, '<' is the pinned baseline and '>' is what this repository produces.
+       Only rule|file|suppressor|count is compared; line numbers and matched prose
+       are excluded on purpose, so a line moving or a sentence being reworded will
+       not show up here. A changed trailing count means the same suppressor is now
+       excusing a different NUMBER of hits for that rule in that file.
+
+       What to do:
+         1. Run  $PY scripts/check_docs_identity.py --self-check
+            and read the RK-IDENT-SUPPRESSED lines.
+         2. For each '>' line with no matching '<': say in review which suppressor
+            is now excusing which prose, and why that prose is legitimately
+            qualified. If it is NOT legitimate, a suppressor has widened -- narrow
+            the rule's 'unless' clause instead of updating this baseline. A line
+            that differs only in its count is that same conversation about the
+            extra hits, not a formality.
+         3. For each '<' line with no matching '>': the prose that needed the
+            excuse is gone or was rewritten. Confirm that is intended.
+         4. Only then update EXPECTED_SUPPRESSION_FINGERPRINT at the top of
+            scripts/test_check_docs_identity.sh to the '>' set."
+  diff <(printf '%s\n' "$EXPECTED_SUPPRESSION_FINGERPRINT") \
+       <(printf '%s\n' "$ACTUAL_SUPPRESSION_FINGERPRINT") | sed 's/^/       | /'
+fi
+
+# The three controls below prove what shape the fingerprint has: what it must catch
+# and what it must ignore. They run against a FIXED SYNTHETIC suppression set, never
+# against this repository's live one.
+#
+# That is the point. Derived from the live baseline, a control asserting "these two
+# fingerprints are equal to EXPECTED" fails the moment the repository legitimately
+# gains or loses a suppression -- so one honest documentation edit would report both
+# "the baseline moved" (true, and the intended review friction) and "the fingerprint
+# no longer ignores line numbers" (false, and a diagnostic pointing at the wrong
+# thing). Pinning the controls to synthetic rows keeps the diagnosis one failure with
+# one cause.
+SYNTH_SUPPRESSIONS="$WORK/synthetic_suppressions.json"
+cat > "$SYNTH_SUPPRESSIONS" <<'EOF'
+{
+  "suppressions": [
+    {"rule": "COLOR_DEPTH", "file": "docs/synthetic_one.md", "line": 12,
+     "match": "24-bit colour", "suppressor": "pixel format"},
+    {"rule": "TOUCH_VARIANT", "file": "docs/synthetic_two.md", "line": 34,
+     "match": "CST816D", "suppressor": "datasheet"}
+  ]
+}
+EOF
+SYNTH_FINGERPRINT="$(cat <<'EOF'
+COLOR_DEPTH|docs/synthetic_one.md|pixel format|1
+TOUCH_VARIANT|docs/synthetic_two.md|datasheet|1
+EOF
+)"
+
+# Control for the three below: the synthetic rows must fingerprint to the stated
+# value, or an assertion of "unchanged" could pass on two empty strings.
+SYNTH_ACTUAL="$(fingerprint "$SYNTH_SUPPRESSIONS")"
+if [ "$SYNTH_ACTUAL" = "$SYNTH_FINGERPRINT" ]; then
+  ok "the synthetic suppression set fingerprints to its stated value"
+else
+  bad "the synthetic suppression set does not fingerprint as stated, so the cases below prove nothing"
+  diff <(printf '%s\n' "$SYNTH_FINGERPRINT") <(printf '%s\n' "$SYNTH_ACTUAL") | sed 's/^/       | /'
+fi
+
+# One: a suppressor swapped for another, with the total unchanged -- the change a
+# scalar total cannot see, and the whole reason the fingerprint carries triples.
+SYNTH_SUBST="$WORK/synthetic_substituted.json"
+if "$PY" -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+d["suppressions"][0]["suppressor"] = "framebuffer format"
+json.dump(d, open(sys.argv[2], "w"))
+' "$SYNTH_SUPPRESSIONS" "$SYNTH_SUBST" 2>/dev/null; then
+  SUBST_ACTUAL="$(fingerprint "$SYNTH_SUBST")"
+  SUBST_N="$(printf '%s\n' "$SUBST_ACTUAL" | grep -c .)"
+  SYNTH_N="$(printf '%s\n' "$SYNTH_FINGERPRINT" | grep -c .)"
+  if [ "$SUBST_N" -ne "$SYNTH_N" ]; then
+    bad "the substitution case changed the line count ($SUBST_N vs $SYNTH_N), so it does not test what it claims"
+  elif [ "$SUBST_ACTUAL" = "$SYNTH_FINGERPRINT" ]; then
+    bad "substituting one suppressor did not change the fingerprint"
+  else
+    ok "a one-for-one suppressor substitution fails the fingerprint at unchanged count ($SYNTH_N)"
+  fi
+else
+  bad "could not build the substituted suppression report"
+fi
+
+# Two: an ADDITIONAL suppressed hit inside a triple that is already pinned. Without
+# the trailing count this is invisible -- the set of triples is unchanged -- and an
+# existing baseline line becomes a standing licence for as many further hits as
+# anyone cares to add under the same excuse. It must fail, and it must fail by the
+# count alone: the added row deliberately carries a different line and different
+# matched prose, neither of which the fingerprint reads.
+SYNTH_EXTRA="$WORK/synthetic_extra_hit.json"
+if "$PY" -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+extra = dict(d["suppressions"][1])
+extra["line"] = 99
+extra["match"] = "a second CST816D sentence in the same file"
+d["suppressions"].append(extra)
+json.dump(d, open(sys.argv[2], "w"))
+' "$SYNTH_SUPPRESSIONS" "$SYNTH_EXTRA" 2>/dev/null; then
+  EXTRA_ACTUAL="$(fingerprint "$SYNTH_EXTRA")"
+  EXTRA_TRIPLES="$(printf '%s\n' "$EXTRA_ACTUAL" | grep -c .)"
+  if [ "$EXTRA_TRIPLES" -ne "$(printf '%s\n' "$SYNTH_FINGERPRINT" | grep -c .)" ]; then
+    bad "the extra-hit case added a new triple, so it does not test what it claims"
+  elif [ "$EXTRA_ACTUAL" = "$SYNTH_FINGERPRINT" ]; then
+    bad "an extra suppressed hit inside an already-pinned triple did not change the fingerprint"
+  elif printf '%s\n' "$EXTRA_ACTUAL" | grep -qxF "TOUCH_VARIANT|docs/synthetic_two.md|datasheet|2"; then
+    ok "an extra suppressed hit in an existing triple fails the fingerprint, and the count says how many"
+  else
+    bad "the extra-hit fingerprint changed but does not report the new count"
+    printf '%s\n' "$EXTRA_ACTUAL" | sed 's/^/       | /'
+  fi
+else
+  bad "could not build the extra-hit suppression report"
+fi
+
+# Three: and it must NOT churn on the two things deliberately excluded, or it would
+# fail so often that updating the constant becomes reflex rather than review. Every
+# line number moves and every matched string is replaced; nothing may change.
+SYNTH_LINESHIFT="$WORK/synthetic_lineshift.json"
+if "$PY" -c '
+import json, sys
+d = json.load(open(sys.argv[1]))
+for r in d["suppressions"]:
+    r["line"] = r["line"] + 1000
+    r["match"] = "entirely different prose"
+json.dump(d, open(sys.argv[2], "w"))
+' "$SYNTH_SUPPRESSIONS" "$SYNTH_LINESHIFT" 2>/dev/null; then
+  if [ "$(fingerprint "$SYNTH_LINESHIFT")" = "$SYNTH_FINGERPRINT" ]; then
+    ok "the fingerprint ignores suppression line numbers and matched prose"
+  else
+    bad "the fingerprint changed when only line numbers and matched prose changed"
+  fi
+else
+  bad "could not build the line-shifted suppression report"
+fi
+
+echo "== precedence: a structure failure never hides a contradiction =="
+
+BOTH="$(fresh_tree both)"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$BOTH/docs/scratch.md"
+grep -v '^## Identity summary' "$BASE/$BOARD" > "$BOTH/$BOARD.tmp"
+mv "$BOTH/$BOARD.tmp" "$BOTH/$BOARD"
+expect_rc "structure outranks violation in the exit code" 2 "$BOTH"
+expect_out "the outranked violation is still printed" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+expect_out "the structure failure is printed too" "RK-IDENT-STRUCTURE"
+
+ALL3="$(fresh_tree all_three)"
+cp "$FIXTURES/retired_marker.md" "$ALL3/docs/scratch.md"
+grep -v '^## Identity summary' "$BASE/$BOARD" > "$ALL3/$BOARD.tmp"
+mv "$ALL3/$BOARD.tmp" "$ALL3/$BOARD"
+rm -f "$ALL3/docs/esp/ROTARY_ENCODER.md"
+expect_rc "missing outranks structure, marker abuse and violation" 3 "$ALL3"
+expect_out "missing is printed" "RK-IDENT-MISSING"
+expect_out "structure is still printed" "RK-IDENT-STRUCTURE"
+expect_out "marker abuse is still printed" "RK-IDENT-MARKER-ABUSE"
+expect_out "the violation is still printed" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+
+echo "== --self-check is live =="
+
+run "$REPO" --self-check
+expect_out "self-check reports zero failures on the shipped rules" "selfcheck=0"
+
+BROKEN="$WORK/broken_checker.py"
+sed 's|r"\\btouch\[\\s_-\]\*amoled\\b"|r"zzz-this-can-never-match"|' "$CHECKER" > "$BROKEN"
+if grep -q 'zzz-this-can-never-match' "$BROKEN"; then
+  BROKEN_OUT="$("$PY" "$BROKEN" --root "$REPO" --self-check 2>/dev/null)"
+  BROKEN_RC=$?
+  if [ "$BROKEN_RC" -eq 4 ] && printf '%s' "$BROKEN_OUT" | grep -qF "RK-IDENT-SELFCHECK"; then
+    ok "a rule whose regex stops matching its own probe fails --self-check (exit 4)"
+  else
+    bad "broken rule table did not fail --self-check (rc=$BROKEN_RC)"
+    printf '%s\n' "$BROKEN_OUT" | sed 's/^/       | /'
+  fi
+  # Without --self-check the broken rule is silently inert: that is exactly why
+  # the flag exists, and CI passes it.
+  BROKEN_OUT="$("$PY" "$BROKEN" --root "$REPO" 2>/dev/null)"
+  BROKEN_RC=$?
+  if [ "$BROKEN_RC" -eq 0 ]; then
+    ok "without --self-check the same breakage is silent (so CI must pass the flag)"
+  else
+    bad "expected the broken checker to pass without --self-check, got $BROKEN_RC"
+  fi
+else
+  bad "could not construct the broken-checker case (patch did not apply)"
+fi
+
+# A suppressor that swallows its own rule is the other way a rule can rot.
+WIDE="$WORK/wide_unless.py"
+sed 's@unless=r"(datasheet@unless=r"(via@' "$CHECKER" > "$WIDE"
+if ! cmp -s "$CHECKER" "$WIDE"; then
+  WIDE_OUT="$("$PY" "$WIDE" --root "$REPO" --self-check 2>/dev/null)"
+  WIDE_RC=$?
+  if [ "$WIDE_RC" -eq 4 ] && printf '%s' "$WIDE_OUT" | grep -qF "also suppresses the rule's own probe"; then
+    ok "an over-wide unless pattern fails --self-check (exit 4)"
+  else
+    bad "over-wide unless pattern did not fail --self-check (rc=$WIDE_RC)"
+    printf '%s\n' "$WIDE_OUT" | sed 's/^/       | /'
+  fi
+else
+  bad "could not construct the over-wide-unless case (patch did not apply)"
+fi
+
+# And an allowance parked on a current-fact section must be refused by
+# self-check, not merely by convention.
+MISPLACED="$WORK/misplaced_allowance.py"
+sed 's|CANONICAL: ("## Historical claims, now superseded",)|CANONICAL: ("## Identity summary",)|' \
+  "$CHECKER" > "$MISPLACED"
+if ! cmp -s "$CHECKER" "$MISPLACED"; then
+  MIS_OUT="$("$PY" "$MISPLACED" --root "$REPO" --self-check 2>/dev/null)"
+  MIS_RC=$?
+  if [ "$MIS_RC" -eq 4 ] && printf '%s' "$MIS_OUT" | grep -qF "must never carry a section allowance"; then
+    ok "an allowance on a current-fact section fails --self-check (exit 4)"
+  else
+    bad "misplaced section allowance did not fail --self-check (rc=$MIS_RC)"
+    printf '%s\n' "$MIS_OUT" | sed 's/^/       | /'
+  fi
+else
+  bad "could not construct the misplaced-allowance case (patch did not apply)"
+fi
+
+# A file skip that is not root-level is refused too, so SKIP_FILES cannot grow
+# into a directory amnesty.
+DEEPSKIP="$WORK/deep_skip.py"
+sed 's|^SKIP_FILES = ("CHANGELOG.md",)$|SKIP_FILES = ("docs/esp/DISPLAY.md",)|' "$CHECKER" > "$DEEPSKIP"
+if ! cmp -s "$CHECKER" "$DEEPSKIP"; then
+  DEEP_OUT="$("$PY" "$DEEPSKIP" --root "$REPO" --self-check 2>/dev/null)"
+  DEEP_RC=$?
+  if [ "$DEEP_RC" -eq 4 ] && printf '%s' "$DEEP_OUT" | grep -qF "root-level only"; then
+    ok "a non-root-level file skip fails --self-check (exit 4)"
+  else
+    bad "non-root file skip did not fail --self-check (rc=$DEEP_RC)"
+    printf '%s\n' "$DEEP_OUT" | sed 's/^/       | /'
+  fi
+else
+  bad "could not construct the deep-skip case (patch did not apply)"
+fi
+
+# Putting .github back into SKIP_DIRS must fail self-check, because that is the
+# regression that made the documented scope and the real scope disagree.
+GHSKIP="$WORK/github_skipped.py"
+sed 's|^        "\.git",$|        ".git",\n        ".github",|' "$CHECKER" > "$GHSKIP"
+if ! cmp -s "$CHECKER" "$GHSKIP"; then
+  GH_OUT="$("$PY" "$GHSKIP" --root "$REPO" --self-check 2>/dev/null)"
+  GH_RC=$?
+  if [ "$GH_RC" -eq 4 ] && printf '%s' "$GH_OUT" | grep -qF "must stay scannable"; then
+    ok "re-excluding .github fails --self-check (exit 4)"
+  else
+    bad "re-excluding .github did not fail --self-check (rc=$GH_RC)"
+    printf '%s\n' "$GH_OUT" | sed 's/^/       | /'
+  fi
+else
+  bad "could not construct the .github-skip case (patch did not apply)"
+fi
+
+echo "== reporting and usage contract =="
+
+REPORT="$WORK/report.json"
+run "$REPO" --self-check --report "$REPORT"
+if [ -s "$REPORT" ] && "$PY" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+assert d['token']=='RK-IDENT-OK', d['token']
+assert d['exit_code']==0
+assert d['violations']==[]
+assert d['marker_abuse']==[]
+assert d['structure_failures']==[]
+assert d['missing']==[]
+assert isinstance(d['suppressions'], list)
+assert all(r['file'] and r['line']>0 and r['rule'] and r['suppressor'] for r in d['suppressions'])
+assert len(d['rules'])>=9
+assert len(d['files_scanned'])>=20
+assert not any(f.startswith('scripts/fixtures') for f in d['files_scanned'])
+assert 'CHANGELOG.md' not in d['files_scanned']
+assert 'README.md' in d['files_scanned']
+assert '.github/RELEASE_TEMPLATE.md' in d['files_scanned']
+" "$REPORT" 2>/dev/null; then
+  ok "--report writes a JSON report whose fields agree with the exit code"
+else
+  bad "--report produced no usable JSON report"
+fi
+
+VIOLREPORT="$WORK/viol.json"
+VTREE="$(fresh_tree violation_report)"
+cp "$FIXTURES/violation_COLOR_DEPTH.md" "$VTREE/docs/scratch.md"
+run "$VTREE" --report "$VIOLREPORT"
+if [ "$RUN_RC" -eq 1 ] && "$PY" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+assert d['token']=='RK-IDENT-VIOLATION', d['token']
+assert d['exit_code']==1
+ids={v['rule'] for v in d['violations']}
+assert 'COLOR_DEPTH' in ids, ids
+assert all(v['line']>0 and v['file'] for v in d['violations'])
+" "$VIOLREPORT" 2>/dev/null; then
+  ok "a failing run still writes a report naming the rule, file and line"
+else
+  bad "failing run did not write a usable report"
+fi
+
+ABUSEREPORT="$WORK/abuse.json"
+ATREE="$(fresh_tree abuse_report)"
+cp "$FIXTURES/other_target_shipping.md" "$ATREE/docs/scratch.md"
+run "$ATREE" --report "$ABUSEREPORT"
+if [ "$RUN_RC" -eq 1 ] && "$PY" -c "
+import json,sys
+d=json.load(open(sys.argv[1]))
+assert d['marker_abuse'], d['marker_abuse']
+assert all(r['file'] and r['line']>0 and r['message'] for r in d['marker_abuse'])
+" "$ABUSEREPORT" 2>/dev/null; then
+  ok "marker abuse is reported with file, line and message"
+else
+  bad "marker abuse report was not usable"
+fi
+
+expect_rc "an unknown flag is a usage error" 64 "$REPO" --no-such-flag
+expect_out "usage error is named" "RK-IDENT-USAGE"
+
+HELP_OUT="$("$PY" "$CHECKER" --help 2>&1)"
+HELP_RC=$?
+if [ "$HELP_RC" -eq 0 ] \
+   && printf '%s' "$HELP_OUT" | grep -qF "phrase tripwire" \
+   && printf '%s' "$HELP_OUT" | grep -qF "not semantic or" \
+   && printf '%s' "$HELP_OUT" | grep -qF "factual proof" \
+   && ! printf '%s' "$HELP_OUT" | grep -qF "RK-IDENT-USAGE"; then
+  ok "--help exits 0 and states the guard's epistemic limit"
+else
+  bad "--help is not successful or does not state the guard's limit (rc=$HELP_RC)"
+  printf '%s\n' "$HELP_OUT" | sed 's/^/       | /'
+fi
+
+# `--quiet` gates only the per-hit suppression and violation lines. Pin the help text
+# to that, and pin the behaviour it describes, so the two cannot drift apart: an
+# earlier "print only the summary token" promised silence it never delivered.
+if printf '%s' "$HELP_OUT" | grep -qF "suppress the per-hit suppression and violation lines" \
+   && ! printf '%s' "$HELP_OUT" | grep -qF "print only the summary token"; then
+  ok "--help describes --quiet as gating only suppression and violation lines"
+else
+  bad "--quiet help text does not match its documented behaviour"
+  printf '%s\n' "$HELP_OUT" | sed 's/^/       | /'
+fi
+
+QUIETCASE="$(fresh_tree quiet_behaviour)"
+cp "$FIXTURES/violation_PANEL_AMOLED.md" "$QUIETCASE/docs/scratch.md"
+cp "$FIXTURES/comment_unterminated.md" "$QUIETCASE/docs/dangling.md"
+cp "$FIXTURES/retired_marker.md" "$QUIETCASE/docs/retired.md"
+run "$QUIETCASE" --quiet
+expect_no_out "--quiet drops the per-hit violation lines" "RK-IDENT-VIOLATION: PANEL_AMOLED"
+expect_no_out "--quiet drops the quoting note printed with them" \
+  "quote source in a fenced code block"
+expect_out "--quiet still prints STRUCTURE lines" "RK-IDENT-STRUCTURE: docs/dangling.md"
+expect_out "--quiet still prints MARKER-ABUSE lines" "RK-IDENT-MARKER-ABUSE: docs/retired.md"
+expect_out "--quiet still prints the summary token" "RK-IDENT-STRUCTURE: files="
+
+expect_rc "an empty --root value is a usage error" 64 ""
+expect_out "empty argument is named" "RK-IDENT-USAGE"
+
+run "$REPO" --report "$WORK/no/such/dir/report.json"
+if [ "$RUN_RC" -eq 64 ]; then
+  ok "an unwritable report path is a usage error (exit 64)"
+else
+  bad "unwritable report path returned $RUN_RC, wanted 64"
+fi
+
+echo "== the step summary renderer =="
+
+# This block exists because the renderer used to be a heredoc inside the workflow
+# and could not be tested. It indexed every detail row as row["rule"], which
+# marker_abuse rows do not have, so the first marker-abuse finding turned the
+# summary into a KeyError -- on exactly the runs that needed a summary.
+SUMMARIZER="$REPO/scripts/summarize_docs_identity.py"
+ALLGROUPS="$FIXTURES/report_all_groups.json"
+
+# sum_run <report path or ''> -> sets SUM_OUT and SUM_RC
+sum_run() {
+  if [ -n "${1:-}" ]; then
+    SUM_OUT="$("$PY" "$SUMMARIZER" --report "$1" 2>/dev/null)"
+  else
+    SUM_OUT="$("$PY" "$SUMMARIZER" 2>/dev/null)"
+  fi
+  SUM_RC=$?
+}
+
+sum_expect() {
+  local label="$1" needle="$2"
+  if printf '%s' "$SUM_OUT" | grep -qF -- "$needle"; then
+    ok "$label"
+  else
+    bad "$label: summary did not contain '$needle'"
+    printf '%s\n' "$SUM_OUT" | sed 's/^/       | /'
+  fi
+}
+
+if [ ! -f "$SUMMARIZER" ]; then
+  bad "renderer missing at scripts/summarize_docs_identity.py"
+elif [ ! -f "$ALLGROUPS" ]; then
+  bad "synthetic report missing at scripts/fixtures/docs_identity/report_all_groups.json"
+else
+  # A synthetic report carrying every group at once, including the marker_abuse
+  # rows that used to crash the heredoc.
+  sum_run "$ALLGROUPS"
+  if [ "$SUM_RC" -eq 0 ]; then
+    ok "renderer exits 0 on a report containing every group"
+  else
+    bad "renderer exited $SUM_RC on the all-groups report"
+    printf '%s\n' "$SUM_OUT" | sed 's/^/       | /'
+  fi
+  sum_expect "renderer never raises KeyError" "Docs identity guard"
+  if printf '%s' "$SUM_OUT" | grep -qiE 'traceback|keyerror'; then
+    bad "renderer output contains a traceback"
+    printf '%s\n' "$SUM_OUT" | sed 's/^/       | /'
+  else
+    ok "renderer output contains no traceback"
+  fi
+
+  # Counts, taken from the fixture: 3 files, 2 rules, 1 violation, 2 marker abuse,
+  # 2 structure failures, 1 missing, 1 self-check failure, 2 suppressions.
+  sum_expect "token row is rendered" '| token | `RK-IDENT-MISSING` |'
+  sum_expect "exit code row is rendered" '| exit code | 3 |'
+  sum_expect "files-scanned count is 3" '| files scanned | 3 |'
+  sum_expect "rules count is 2" '| rules | 2 |'
+  sum_expect "violations count is 1" '| violations | 1 |'
+  sum_expect "marker-abuse count is 2" '| marker abuse | 2 |'
+  sum_expect "structure count is 2" '| structure failures | 2 |'
+  sum_expect "missing count is 1" '| missing | 1 |'
+  sum_expect "self-check count is 1" '| self-check failures | 1 |'
+  sum_expect "suppression count is rendered as informational" \
+    '| suppressions (informational) | 2 |'
+
+  # Every group renders a heading and a usable detail line.
+  sum_expect "violations section is present" "### violations"
+  sum_expect "violation detail names rule, file, line and message" \
+    '- `PANEL_AMOLED` docs/esp/hw-reference/board.md:27'
+  # The indented-code consequence is rendered from the report, beneath the findings
+  # it explains, so a reader of the step summary meets the remedy where the
+  # violations are rather than in the checker's docstring.
+  sum_expect "the violations section renders the report's quoting note" \
+    "a four-space indented block is scanned as prose"
+  sum_expect "marker-abuse section is present" "### marker abuse"
+  sum_expect "marker-abuse detail names file and line without a rule" \
+    "- docs/howto/PORTING.md:42"
+  sum_expect "second marker-abuse row is rendered too" "- docs/esp/DISPLAY.md:9"
+  sum_expect "structure section is present" "### structure failures"
+  sum_expect "structure detail is rendered" "corrected value 'ST77916' no longer present"
+  sum_expect "an unterminated-fence structure row is rendered" \
+    "docs/esp/DISPLAY.md:12: unterminated code fence"
+  sum_expect "missing section is present" "### missing"
+  sum_expect "missing detail is rendered" "required document absent: docs/esp/ROTARY_ENCODER.md"
+  sum_expect "self-check section is present" "### selfcheck failures"
+  sum_expect "self-check detail is rendered" "probe does not match its own pattern"
+
+  # Suppressions render under their own heading, carry the suppressor as evidence,
+  # and are labelled informational so a reader does not read them as findings.
+  sum_expect "suppressions section is present and labelled" "### suppressions (informational)"
+  sum_expect "suppressions section explains it does not affect the exit code" \
+    "do not affect the exit code"
+  sum_expect "a suppression row names rule, file, line, match and suppressor" \
+    '- `TOUCH_VARIANT` docs/esp/hw-reference/cst816d.md:8 — CST816D suppressed by `datasheet`'
+  sum_expect "the second suppression row is rendered too" \
+    '- `COLOR_DEPTH` docs/esp/hw-reference/board.md:118 — 24-bit colour suppressed by `RGB888`'
+
+  SUM_LINES="$(printf '%s\n' "$SUM_OUT" | grep -c '^- ')"
+  if [ "$SUM_LINES" -eq 9 ]; then
+    ok "exactly the nine synthetic detail rows are rendered"
+  else
+    bad "expected 9 detail lines, got $SUM_LINES"
+    printf '%s\n' "$SUM_OUT" | sed 's/^/       | /'
+  fi
+
+  # A clean report renders the counts, no detail sections, and the honesty note.
+  CLEANREPORT="$WORK/clean_report.json"
+  run "$REPO" --self-check --report "$CLEANREPORT"
+  sum_run "$CLEANREPORT"
+  if [ "$SUM_RC" -eq 0 ]; then
+    ok "renderer exits 0 on the repository's own clean report"
+  else
+    bad "renderer exited $SUM_RC on a clean report"
+  fi
+  sum_expect "clean report renders the OK token" '| token | `RK-IDENT-OK` |'
+  if printf '%s' "$SUM_OUT" \
+      | grep -qE '^### (violations|marker abuse|structure failures|missing|selfcheck failures)$'; then
+    bad "clean report rendered a finding section"
+    printf '%s\n' "$SUM_OUT" | sed 's/^/       | /'
+  else
+    ok "clean report renders no finding sections"
+  fi
+  # The repository's own report carries suppressions, and they must be visible
+  # without being mistaken for findings: the informational section renders and the
+  # closing "nothing found" note still appears.
+  sum_expect "clean report still renders the informational suppressions section" \
+    "### suppressions (informational)"
+  sum_expect "clean report states the tripwire limit" "phrase tripwire, not a proof"
+
+  # A report with findings *and* suppressions renders both, and a report with no
+  # suppressions renders no suppressions section at all.
+  printf '{"token": "RK-IDENT-OK", "exit_code": 0, "suppressions": []}' \
+    > "$WORK/no_suppressions.json"
+  sum_run "$WORK/no_suppressions.json"
+  if printf '%s' "$SUM_OUT" | grep -qF "### suppressions"; then
+    bad "an empty suppressions list still rendered a section"
+    printf '%s\n' "$SUM_OUT" | sed 's/^/       | /'
+  else
+    ok "an empty suppressions list renders no section"
+  fi
+  sum_expect "an empty suppressions list still renders a zero count" \
+    '| suppressions (informational) | 0 |'
+
+  # Degraded inputs must still be exit 0 and must say so in prose, because the
+  # workflow calls this with if: always().
+  sum_run "$WORK/no_such_report.json"
+  if [ "$SUM_RC" -eq 0 ]; then
+    ok "a missing report is exit 0"
+  else
+    bad "missing report exited $SUM_RC"
+  fi
+  sum_expect "missing report is named as unusable" "No usable report"
+
+  printf 'not json at all' > "$WORK/broken_report.json"
+  sum_run "$WORK/broken_report.json"
+  if [ "$SUM_RC" -eq 0 ]; then
+    ok "a malformed report is exit 0"
+  else
+    bad "malformed report exited $SUM_RC"
+  fi
+  sum_expect "malformed report is named as unusable" "No usable report"
+
+  # A report missing the fields the renderer reads must degrade, not raise.
+  printf '{"token": "RK-IDENT-VIOLATION", "violations": [{"file": "x.md"}, "a bare string"]}' \
+    > "$WORK/partial_report.json"
+  sum_run "$WORK/partial_report.json"
+  if [ "$SUM_RC" -eq 0 ]; then
+    ok "a report with absent fields is exit 0"
+  else
+    bad "partial report exited $SUM_RC"
+    printf '%s\n' "$SUM_OUT" | sed 's/^/       | /'
+  fi
+  sum_expect "absent counts degrade to a placeholder" '| files scanned | ? |'
+  sum_expect "a row without a line still renders its file" "- x.md"
+  sum_expect "a string row inside a dict group still renders" "- a bare string"
+
+  sum_run ""
+  if [ "$SUM_RC" -eq 0 ]; then
+    ok "no --report and no RK_IDENT_REPORT is exit 0"
+  else
+    bad "renderer with no report path exited $SUM_RC"
+  fi
+
+  if RK_IDENT_REPORT="$ALLGROUPS" "$PY" "$SUMMARIZER" 2>/dev/null \
+      | grep -qF '| marker abuse | 2 |'; then
+    ok "RK_IDENT_REPORT is honoured when --report is absent"
+  else
+    bad "RK_IDENT_REPORT was not honoured"
+  fi
+
+  if "$PY" "$SUMMARIZER" --no-such-flag >/dev/null 2>&1; then
+    ok "an unknown flag is still exit 0 (a summary must never fail the step)"
+  else
+    bad "an unknown flag made the renderer exit non-zero"
+  fi
+
+  # A bad invocation and `--help` both leave argparse via SystemExit, so the
+  # always-exit-0 contract used to answer `--help` with "invoked incorrectly".
+  # `--help` must print argparse's own help and nothing else.
+  SUMHELP_OUT="$("$PY" "$SUMMARIZER" --help 2>&1)"
+  SUMHELP_RC=$?
+  if [ "$SUMHELP_RC" -eq 0 ] \
+     && printf '%s' "$SUMHELP_OUT" | grep -qF -- "--report" \
+     && ! printf '%s' "$SUMHELP_OUT" | grep -qF "invoked incorrectly"; then
+    ok "--help prints help and is not reported as an incorrect invocation"
+  else
+    bad "--help was swallowed into the incorrect-invocation path (rc=$SUMHELP_RC)"
+    printf '%s\n' "$SUMHELP_OUT" | sed 's/^/       | /'
+  fi
+
+  # ... while a genuinely bad invocation still says so, and still exits 0.
+  SUMBAD_OUT="$("$PY" "$SUMMARIZER" --no-such-flag 2>/dev/null)"
+  SUMBAD_RC=$?
+  if [ "$SUMBAD_RC" -eq 0 ] \
+     && printf '%s' "$SUMBAD_OUT" | grep -qF "invoked incorrectly"; then
+    ok "a bad invocation still renders the incorrect-invocation summary at exit 0"
+  else
+    bad "a bad invocation no longer names itself (rc=$SUMBAD_RC)"
+    printf '%s\n' "$SUMBAD_OUT" | sed 's/^/       | /'
+  fi
+fi
+
+echo "== the workflow calls what the tests cover =="
+
+WF="$REPO/.github/workflows/docs-identity.yml"
+if [ ! -f "$WF" ]; then
+  bad "workflow missing at .github/workflows/docs-identity.yml"
+else
+  for needle in \
+    'bash scripts/test_check_docs_identity.sh' \
+    'scripts/check_docs_identity.py' \
+    'scripts/summarize_docs_identity.py' \
+    '--self-check' \
+    'contents: read' \
+    'persist-credentials: false' \
+    'cancel-in-progress'; do
+    if grep -qF -- "$needle" "$WF"; then
+      ok "workflow references $needle"
+    else
+      bad "workflow does not reference $needle"
+    fi
+  done
+  # No path filters: a skipped job cannot be a meaningful required status check.
+  if grep -qE '^\s*paths:' "$WF"; then
+    bad "workflow still has a paths: filter, so it can be skipped on a pull request"
+  else
+    ok "workflow has no paths: filter, so it always reports"
+  fi
+  # No embedded interpreter block: the renderer must stay a tested file.
+  if grep -qE 'python3 - ' "$WF"; then
+    bad "workflow still embeds an inline Python program"
+  else
+    ok "workflow embeds no inline Python program"
+  fi
+fi
+
+echo "== the guard is reachable locally, without ESP-IDF =="
+
+# A guard that only ever runs in one workflow is a guard contributors meet for the
+# first time in a red pull request. The local route is the direct command, named in
+# the two documents a contributor or an agent actually reads before editing docs.
+#
+# It is deliberately NOT wired into scripts/ci_sanity.sh. That script's very next
+# step is `idf.py build`, so it cannot run on a host without ESP-IDF, which is the
+# host this guard exists for; it is not exercised by any workflow in this
+# repository; and a check bolted to the front of a script nobody can run is not a
+# gate. A direct command that works everywhere is the honest version.
+LOCAL_CMD='python3 scripts/check_docs_identity.py --self-check'
+
+# The invocation itself: standard library Python, no cmake, no idf.py, no network.
+LOCAL_OUT="$("$PY" "$CHECKER" --self-check 2>/dev/null)"
+LOCAL_RC=$?
+if [ "$LOCAL_RC" -eq 0 ] && printf '%s' "$LOCAL_OUT" | grep -qF "RK-IDENT-OK"; then
+  ok "the documented local command succeeds on this host with no ESP-IDF present"
+else
+  bad "the documented local command failed standalone (rc=$LOCAL_RC)"
+  printf '%s\n' "$LOCAL_OUT" | sed 's/^/       | /'
+fi
+
+# Both documents must name the command verbatim, so the instruction and the command
+# cannot drift apart.
+for doc in AGENTS.md docs/dev/DEVELOPMENT.md; do
+  if [ ! -f "$REPO/$doc" ]; then
+    bad "$doc missing"
+  elif grep -qF "$LOCAL_CMD" "$REPO/$doc"; then
+    ok "$doc names the local command verbatim"
+  else
+    bad "$doc does not name '$LOCAL_CMD'"
+  fi
+done
+
+# Consistency, in the direction that actually rots: the documentation must not
+# describe a local gate that is not wired up. Rather than trying to forbid a claim
+# in prose, the correct claim is pinned as an exact phrase -- so the state of
+# scripts/ci_sanity.sh and the state of the documents cannot disagree without a
+# failure here, in either direction.
+SANITY="$REPO/scripts/ci_sanity.sh"
+SANITY_DISCLAIMER='not wired into `scripts/ci_sanity.sh`'
+if [ ! -f "$SANITY" ]; then
+  bad "scripts/ci_sanity.sh missing"
+elif grep -qF 'check_docs_identity.py' "$SANITY"; then
+  # Someone wired it in for real. Then --self-check is mandatory, and the documents
+  # must stop saying it is not wired in.
+  if grep -A2 -F 'check_docs_identity.py' "$SANITY" | grep -qF -- '--self-check'; then
+    ok "ci_sanity.sh runs the guard, and does so with --self-check"
+  else
+    bad "ci_sanity.sh runs the guard without --self-check"
+  fi
+  STALE="$(grep -lF "$SANITY_DISCLAIMER" "$REPO/$ADR" "$REPO/docs/dev/DEVELOPMENT.md" 2>/dev/null || true)"
+  if [ -z "$STALE" ]; then
+    ok "no document still says the guard is not wired into ci_sanity.sh"
+  else
+    bad "ci_sanity.sh now runs the guard, but these files still say it does not:
+$(printf '%s\n' "$STALE" | sed 's/^/       | /')"
+  fi
+else
+  for doc in "$ADR" docs/dev/DEVELOPMENT.md; do
+    if grep -qF "$SANITY_DISCLAIMER" "$REPO/$doc"; then
+      ok "$doc states that the guard is not wired into ci_sanity.sh"
+    else
+      bad "ci_sanity.sh does not run the guard, but $doc does not say so"
+    fi
+  done
+fi
+
+echo
+printf 'RK-IDENT-FIXTURES: passed=%d failed=%d\n' "$PASS" "$FAIL"
+if [ "$FAIL" -ne 0 ]; then
+  echo "RK-IDENT-FIXTURES-FAIL"
+  exit 1
+fi
+echo "RK-IDENT-FIXTURES-OK"


### PR DESCRIPTION
Closes #211

## Problem

The repository described its only shipping target inconsistently, across nine files:

- `README.md` named the Waveshare **ESP32-S3-Knob-Touch-LCD-1.8**; `docs/esp/hw-reference/board.md` named an "ESP32-S3 Touch AMOLED 1.8″".
- `board.md` claimed 16.7M colours and stated no backlight control was needed — while the firmware configures an LEDC PWM backlight on GPIO 47.
- Several documents called `SH8601` the display controller. That is the name of a *software component*, not of the driver IC the vendor declares (ST77916).
- `DEVELOPMENT.md` advertised an encoder push button that no code reads, and `README.md` advertised a knob press that no code implements.

The first cut of this correction reproduced the same failure in miniature: it stated the firmware drives the backlight at 50% duty, which is what a stale comment at `platform_display_idf.c:456` says, not what the code does — the channel configuration at `platform_display_idf.c:471` reads `CONFIG_RK_BACKLIGHT_NORMAL`, default 100/255 (about 39%).

## Outcome

- **`docs/esp/hw-reference/board.md` is the single canonical identity record.** No second `TARGET_IDENTITY.md` — two identity files is the defect, not the fix.
- **Every fact carries a provenance class**: vendor-declared, repository-observed, release-artifact-observed, historical/superseded, or physically unverified. Unverified facts are listed with what blocks them and are treated as verified nowhere.
- **Other documents keep only the facts they own** and link to the canonical record instead of independently restating product identity.
- **Repository-observed facts are derived from values and call sites, never from source comments.** Where a stale comment exists it is named as stale.
- **`scripts/check_docs_identity.py`** — a host-only tripwire (standard library, no network) scanning non-exempt `.md` files at any depth, including `.github/**`; only the contradiction fixtures under `scripts/fixtures/` and the bot-managed root `CHANGELOG.md` are excluded. It ships with a 355-case fixture suite and an advisory `.github/workflows/docs-identity.yml`.
- Full rationale, rejected alternatives, and the exemption model: `docs/meta/decisions/2026-07-30_DECISION_TARGET_IDENTITY_PROVENANCE.md`.

### What the guard is, and is not

The guard is **nine regular expressions over normalised prose — a phrase tripwire, not semantic or factual proof.** A relapse is **not** guaranteed to become a CI failure; only a relapse in a known or tested wording is. Prose that never names a guarded token ("the screen makes its own light"), a colour depth given only as a hex range, a claim carried in an image, a diagram or a translated spec table, and any file this scan does not read, all pass.

Its demonstrated recall, for the single-physical-line renderings in the fitted fixtures, is exactly two sets: the wordings actually present in this repository before #211, each pinned by a rule probe and a fixture; and the paraphrases in `scripts/fixtures/docs_identity/paraphrases.tsv`, authored outside the checker so that "the regex matches its own example" cannot be mistaken for coverage. That corpus exists because a dissent pass wrote fifteen ordinary-prose restatements of these contradictions and the first rule table caught only three; rules were widened until all fifteen are reported. `paraphrases_clean.tsv` pins fourteen truthful sentences sharing vocabulary with guarded phrases that must stay accepted, so a rule cannot drift into a topic ban unnoticed.

Matching is per physical line, so wrapping can split a guarded phrase and make it pass; the fixture suite pins all three named blind spots as current behaviour. The single-record invariant is also enforced by review, not discovered automatically by the hand-maintained link list. **Human review of identity claims remains required.** The check's job is to make cheap relapses loud, and to make any widening of the exemptions a reviewed change to a Python file rather than a documentation edit. Do not trust a green check in place of reading the claim.

## Validation (exact)

All run on host; no device required.

| Gate | Command | Result |
|---|---|---|
| Fixture suite | `bash scripts/test_check_docs_identity.sh` | `RK-IDENT-FIXTURES: passed=355 failed=0` → `RK-IDENT-FIXTURES-OK` |
| Checker self-check | `python3 scripts/check_docs_identity.py --self-check` | `RK-IDENT-OK: files=52 rules=9 violations=0 structure=0 missing=0 selfcheck=0 suppressed=6 anchors_fresh=13/13`, exit 0 |
| Whitespace | `git diff --check` / `git diff --cached --check` | exit 0, no output |
| Byte-cache hygiene | `find . -name __pycache__ -o -name '*.pyc'` (excluding `.git/`) | no results |
| Rebase need | `git merge-base HEAD origin/master` == `origin/master` | fast-forward; no rebase, no conflict resolution, no scope change |

Commit is 57 files, +6266/−143, against base `bc700e95b9d982859c0aff9b8bdfcc6a94369ef9`.

## Scope and status

- **The `docs-identity` workflow is advisory until #205.** There is no `paths:` filter, so it always reports rather than being *skipped* on changes touching no Markdown — a required check that can be skipped is one that can be bypassed. It is host-only (`contents: read`, own `concurrency` group, no ESP-IDF container, no artifacts), so requiring it later adds one short job and no coupling to `docker.yml` or to unmerged release-config work in PR #204. Until #205 acts, a red run is visible here but does not block a merge.
- **Flash geometry and managed-component pinning remain #203.** The v2.5.1 flash-size disagreement (merged header nibble `0x3` = 8 MB, application header nibble `0x4` = 16 MB) is *recorded with reproducible commands, not acted on*. No geometry decision is made here; #203's 16 MB direction still depends on physical flash verification.
- **No hardware test is required for this slice.** It is documentation plus host-only tooling; no firmware source, Kconfig, or build input changes. Physical invariants are revisited when #189 produces readings (decision 9) — until then no `U` fact may be restated as verified.
- **Gate evidence is posted as PR comments.** Only reports whose `head_sha` matches the current PR HEAD count; reports at earlier HEADs are superseded. The final mechanical-adherence comment is authoritative for completeness.

### Gate adjustments incorporated

Phase-gate findings are fixed in this PR rather than left as prose debt:

1. **Comments and fences fail loud.** Unterminated HTML comments and unbalanced/mismatched Markdown fences are `STRUCTURE` failures naming the opening line; valid fenced examples remain exempt.
2. **Rule-level suppressions are observable and fingerprinted.** Every `unless` hit is recorded in JSON, stdout counters, and the CI step summary while remaining non-failing for truthful qualified prose; the 355-case suite pins the exact `rule|file|suppressor|count` fingerprint, so a one-for-one substitution fails even when the count stays six.
3. **Stable repository evidence has relationship-preserving source anchors.** Thirteen anchors cover a deliberate subset of positively quotable R rows, including QSPI pins, backlight configuration, init-array binding, encoder/touch call sites, and zone-picker entry/handling. `13/13` is table health, not total R-row coverage; cited line numbers, negative/uniqueness claims, derived counts, outside-repository diffs, and physical truth remain human-review work tracked in #213.
4. **The guard is directly reachable and honest about its limits.** `AGENTS.md` and `docs/dev/DEVELOPMENT.md` name the host-only command; it is deliberately not wired into dormant `scripts/ci_sanity.sh`. `--help` exits 0 and states the epistemic limits, and a fixture proves pure source-line movement leaves anchors green while literal `:NN` citations can go stale.

5. **Fresh final-review findings are covered by executable regressions.** Visible section state is derived only after stripping HTML comments; punctuation-adjacent anchor whitespace may close while word-to-word gaps remain mandatory; both CLI help paths are pinned; fixture mutations fail loud; and the hardware reproduction blocks now state their actual host prerequisites and valid esptool v4/v5 commands.

6. **The final solution review corrected its own canonical-record class of defect.** The stale source comment literally contains 50%, so the record now says the narrower true claim: no `128` literal exists and no code path implements the stale 50% claim. The same wording is used in the ADR and checker rationale.

7. **Exact citations replaced directional prose.** The stale 50% comment is at `platform_display_idf.c:456`; the Kconfig duty read is explicitly cited at `:471`, rather than described imprecisely as the next line.

8. **Dissent narrowed the enforcement claim.** Recall evidence now applies explicitly to single-physical-line fixture renderings; a wrapped controller claim is pinned as a known passing blind spot; the ADR states that human review, not the checker, enforces the single-record invariant; and rule-local retirement triggers plus #213 own multi-target and real-press evolution.

9. **The enforcement boundary now covers its obvious consumers and its stated pins.** Root `README.md` links to the canonical record and is in `REQUIRE_CANONICAL_LINK`; all three named wrap-vulnerable rules have executable passing blind-spot pins; rule-local retirement triggers are fixture-pinned; and a reproducible `textwrap.wrap` estimate records 120/1,320 missed offsets (9.1%) at 88 columns and 120/1,500 (8.0%) at 100 as fitted-data sensitivity, not a held-out recall guarantee. #213 carries the operational five-PR tally.

10. **Canonical links now resolve rather than merely look plausible.** Required Markdown targets are resolved relative to each referring file and must equal the existing canonical path; a dead path ending in `board.md` is a structure failure. The paraphrase corpus and wrap figures are explicitly labelled fitted data, while #213 requires held-out wording before #205 can require the check. The unposted #117 draft deliberately remains durable PR metadata rather than shipped documentation, and ownership/milestone assignment remains an explicit maintainer choice.

11. **Execute dissent hardened failure quality.** Suppression governance now includes per-triple multiplicity and its shape controls use fixed synthetic data; four-space indented source remains scanned but every violation/report/summary names the fenced-block remedy; anchor false positives have a standing re-derive-and-rewrite-token rule, never delete-to-green; and the fixture suite is 355 cases. The dissent example `50 * 1000` was corrected: only `5 * 1000` preserves 5 kHz.

[#213](https://github.com/muness/roon-knob/issues/213) now retains the deeper governance work: alternation-branch evidence, usable multi-target fixtures, encoder-rule revision/retirement before a real press gesture, and intentional document-rename coupling. It still blocks #205 from making this job required.

---

## Proposed reply for #117 — NOT POSTED

> **This is a draft for maintainer review only.** It has **not** been posted to #117, and nothing in this PR posts it. Per decision 7 of the decision record, posting requires explicit maintainer confirmation, which this PR does not grant. It is included here so it is read in the same place as the evidence it rests on.

<details>
<summary>Proposed wording</summary>

> Correcting my earlier reply on this thread: I described the target as an "SH8601 (QSPI)" display. `esp_lcd_sh8601` is the name of the software component this project builds against, not the driver IC the vendor declares. That was wrong and it has sent porting work after the wrong part.
>
> What the vendor declares for the shipping target (Waveshare ESP32-S3-Knob-Touch-LCD-1.8), now recorded with provenance in `docs/esp/hw-reference/board.md`:
>
> - **Display driver IC:** ST77916
> - **Panel:** 360×360 round IPS LCD
> - **Touch:** CST816 family
> - **SoC:** ESP32-S3R8
>
> On this repository's own evidence, the project replaces the `esp_lcd_sh8601` component's vendor-specific init array with a 185-entry sequence that is byte-for-byte Waveshare's own for this product, and is structurally an ST77916-family sequence (0.8928 opcode-sequence similarity to Espressif's `esp_lcd_st77916` SPI default, longest equal run 175) with zero opcode overlap with the SH8601 component's default. That corroborates the vendor's ST77916 declaration. It is not a claim about physical silicon — no one here has read the markings on a panel.
>
> Two blockers remain for other boards, and I don't want to paper over either:
>
> 1. **The GPIO pin mapping for any other board is unknown to this repository.** We have no pinout for hardware we don't have.
> 2. **This firmware requires a rotary encoder.** Boards without one do not provide what it needs, regardless of display or touch compatibility.
>
> So I can't tell you this "should probably work" on a similar board — that was guess-shaped and I'm retracting it. Where a fact is unverified here, it now says so.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Controls reference to use tap-based actions for zone selection and centre-button play/pause.
  * Introduced/expanded a canonical hardware identity record with provenance rules, plus refreshed display, touch, encoder, wiring, RGB565 byte-order, boot sequence, testing, architecture, and porting documentation to match current setup and interaction behavior.

* **Quality**
  * Added an automated documentation-identity guard with a self-check command, fixture-based validation, JSON reporting, and CI-rendered step summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









