### PR TITLE
#190: Enforce initial controller boundary contracts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,27 @@ jobs:
       - name: Test shared configuration contracts
         run: |
           python3 scripts/check_dial_identity.py
+          python3 scripts/check_controller_dependencies.py
+          python3 scripts/check_controller_dependencies.py --self-test
+          cc -std=c11 -Wall -Wextra -Werror -pthread \
+            -Icommon -Iinclude \
+            tests/test_controller_input.c \
+            common/controller_input.c \
+            common/platform/platform_task.c \
+            -o /tmp/test-controller-input
+          /tmp/test-controller-input
+          cc -std=c11 -Wall -Wextra -Werror \
+            -Icommon -Iinclude \
+            tests/test_controller_presentation_dial.c \
+            idf_app/main/controller_presentation_dial.c \
+            -o /tmp/test-controller-presentation-dial
+          /tmp/test-controller-presentation-dial
+          cc -std=c11 -Wall -Wextra -Werror \
+            -Icommon -Iinclude -Iframe_app/main \
+            tests/test_controller_presentation_frame.c \
+            frame_app/main/controller_presentation_frame.c \
+            -o /tmp/test-controller-presentation-frame
+          /tmp/test-controller-presentation-frame
           cc -std=c11 -Wall -Wextra -Werror \
             -Icommon tests/test_rk_cfg.c -o /tmp/test-rk-cfg
           /tmp/test-rk-cfg

--- a/.oh/controller-boundaries.md
+++ b/.oh/controller-boundaries.md
@@ -1,0 +1,79 @@
+# Controller boundary characterization — issue #190
+
+## Session
+
+- Phase: execute
+- Status: complete; awaiting independent review and dissent
+- Baseline: `1e572377c209267bdd27f73f3371b697fabe3c17`
+- Branch: `codex/issue-190-boundary-contract`
+- Stack: #216 → #217 → #218 → this slice
+- Agent policy: Terra review/dissent; no Claude/Sonnet or Superego tooling
+
+## Aim
+
+Make the first controller boundaries enforceable and behaviorally characterized
+without treating the current transitional APIs as the finished adaptive
+architecture.
+
+## Pre-flight
+
+- Aim is clear: prevent new coupling while preserving the working Dial and
+  Frame paths.
+- Constraints are known: no directory moves, no cross-device configuration
+  transfer, no adaptive protocol, and no large `bridge_client` extraction.
+- Context is loaded: #216 established presentation/input seams, #217 exercises
+  queued BLE input, and #218 changes identity only.
+- Scope is bounded: architecture decision, exact direct-include policy, negative
+  policy fixture, and deterministic input/presentation characterization.
+- Success is explicit: new or stale restricted edges fail; queue/input and both
+  target presentation adapters have native contract tests; both embedded
+  targets still build.
+
+## Selected solution
+
+Use a contract-first strangler:
+
+1. Record the desired dependency DAG separately from the observed graph.
+2. Label current APIs as retained, transitional, or target-owned.
+3. Enforce only direct quoted includes in this slice. Do not claim component or
+   link dependency isolation while both targets still build a single IDF
+   component.
+4. Inventory each permitted restricted edge exactly. Transitional exceptions
+   require an owner and retirement condition; wildcard exceptions are invalid.
+5. Characterize stable semantics rather than pixels, timing, or incidental call
+   order.
+
+## Execute
+
+**Updated:** 2026-07-31
+**Status:** complete
+
+Implementation is intentionally stacked and must remain draft until the
+underlying Dial/Frame hardware evidence and final rebases exist.
+The final merge candidate must target `master` and pass the full workflow; the
+current `pull_request` branch filter does not run it on intermediate stack PRs.
+
+### Evidence
+
+- Exact dependency policy passes with 190 allowed and 25 individually owned,
+  grandfathered edges.
+- Adversarial fixtures prove a comment-separated, line-spliced new target
+  include, an ownerless forbidden edge, and `list(APPEND)`, inline `SRCS`,
+  `target_sources`, `add_subdirectory`, and CMake `include` source mutations
+  fail closed, as do a source synthesized through `set_property` and ESP-IDF
+  `SRC_DIRS` mutation.
+- Native input, Dial presentation, Frame presentation, configuration, and BLE
+  HID contracts pass with warnings treated as errors.
+- Clean ESP-IDF v5.5.5 ESP32-S3 builds pass for both targets.
+- Both generated configurations select `CONFIG_COMPILER_OPTIMIZATION_PERF=y`
+  and do not select `CONFIG_COMPILER_OPTIMIZATION_DEBUG=y`.
+- Dial binary: `0x1b8010` bytes; Frame binary: `0x103710` bytes.
+
+## Explicit exclusions
+
+- Closing #190 from this first slice.
+- Moving `idf_app/`, `frame_app/`, or `common/`.
+- Sharing or migrating NVS blobs between devices.
+- Implementing versioned adaptive server payloads or command IDs.
+- Canonizing picker queries or the current command-bound input enum.
+- Treating native tests as Wi-Fi/BLE/e-ink hardware proof.

--- a/docs/meta/decisions/2026-07-31_DECISION_CONTROLLER_BOUNDARY_ENFORCEMENT.md
+++ b/docs/meta/decisions/2026-07-31_DECISION_CONTROLLER_BOUNDARY_ENFORCEMENT.md
@@ -1,0 +1,149 @@
+# Incremental controller boundary enforcement
+
+**Date:** 2026-07-31
+**Status:** Accepted for the first #190 execution slice
+**Issue:** #190
+
+## Context
+
+The Dial and recovered Frame now share controller input and presentation seams,
+but the broader source graph still mixes backend protocol, controller state,
+commands, configuration, connectivity, recovery, rendering, and target
+hardware. A directory rewrite would hide rather than reduce this risk.
+
+This decision distinguishes the architecture we want from the graph that exists
+today. It creates a ratchet: existing debt is explicit and owned, while new
+direct source coupling fails CI.
+
+## Target dependency direction
+
+```text
+target display, input, BLE, power, and provisioning drivers
+                              |
+                              v
+target composition root -> normalized input -> controller commands
+                              |                    |
+                              |             controller runtime
+                              |      state, recovery, configuration ports
+                              |                    |
+                              +-- presentation <- semantic controller view
+                                                   |
+                                            backend adapter
+```
+
+The dependency rules are:
+
+1. Controller state and command code does not include LVGL, e-ink, GPIO, BLE
+   implementation, captive-portal, or target application headers.
+2. Backend adapters translate transport protocols into typed controller state
+   and commands. They do not include target input or renderer APIs.
+3. Presentation adapters consume controller updates and call one target
+   renderer. Renderers do not fetch backend state directly.
+4. Input drivers emit normalized physical events. Binding events to commands
+   belongs above the driver.
+5. Connectivity publishes events and accepts narrow configuration mutations; it
+   does not render UI directly.
+6. A configuration service owns in-memory mutations. Target storage persists
+   only that device's local configuration. No target imports another target's
+   NVS namespace, blob, settings, or bonds.
+7. Target composition roots are the only layer that assembles display, input,
+   BLE, power, provisioning, controller, and backend adapters.
+
+## Observed graph and API disposition
+
+The first two seams are useful but transitional:
+
+| Surface | Disposition | Reason |
+|---|---|---|
+| `controller_input_post_action` and UI queue dispatch | retained | Cross-task input must be serialized before network or presentation work |
+| Current `controller_input_action_t` names | transitional | They mix physical input and already-bound command meaning; #194 owns configurable bindings |
+| `controller_presentation` target selection | retained | Link-time Dial/Frame adapters remove renderer conditionals from shared controller code |
+| Zone-picker visibility, scrolling, and selected-ID queries | transitional | They model the current imperative picker, not the future semantic adaptive view |
+| Dial LVGL and Frame e-ink implementations | target-owned | Pixel layout, refresh cadence, and target state remain outside the controller |
+| `bridge_client` | transitional mixed runtime | It currently owns protocol, state, commands, configuration, polling/recovery, and presentation scheduling |
+
+Known reverse or mixed-responsibility edges are recorded individually in
+`scripts/controller_dependency_policy.json`. The policy has no wildcard or
+directory-level exception. Every transitional edge names an issue and a
+retirement condition.
+
+## Enforcement boundary
+
+The first slice enforces direct quoted C header includes only:
+
+- every repository-local quoted include reachable from each target's literal
+  `SRC_FILES` inventory is an exact checked edge;
+- an unlisted new edge fails;
+- a removed edge leaves a stale manifest entry and fails until the exception or
+  allowance is retired;
+- known forbidden directions are machine-classified, so they cannot be added as
+  ownerless allowances;
+- unsupported `SRC_FILES` mutation, unresolved repository includes, local
+  angle-bracket includes, and macro includes fail instead of being skipped;
+- the CMake contract requires `SRCS ${SRC_FILES}` exclusively and rejects
+  every command outside the current manifest allowlist, including inline
+  sources, `list(APPEND ...)`, `target_sources(...)`, `add_subdirectory(...)`,
+  and `include(...)` indirection, and rejects ESP-IDF `SRC_DIRS` or
+  `EXCLUDE_SRCS` source mutation;
+- the only accepted `set` and `set_property` forms are the literal source
+  inventory and the two existing non-source build properties;
+- adversarial fixtures prove rejection of a previously unknown target header,
+  comment-separated and line-spliced include tokens, an ownerless forbidden
+  edge, and seven compiled-source bypass forms.
+
+This does **not** claim IDF component-level or link-level separation. Both
+targets still compile shared and target files in one component. Later #190
+slices may strengthen the check after the source graph is split. External
+angle-bracket includes, preprocessor condition semantics, symbols, and runtime
+calls remain outside this source-include contract.
+
+Because stacked PRs target their predecessor rather than `master`, the current
+workflow branch filter does not execute on every intermediate stack PR. Local
+evidence is required while stacked; the final rebased merge candidate must run
+this full workflow against `master` and pass before merge.
+
+## Characterization boundary
+
+Native tests freeze externally useful semantics:
+
+- input handler registration and unset-handler safety;
+- rejection of `CONTROLLER_INPUT_NONE`;
+- UI queue FIFO order, effective capacity, full-queue failure, and reentrant
+  posting;
+- Dial and Frame presentation adapters forwarding semantic values to their
+  target renderer;
+- intentional target differences, such as Dial ignoring `line3` and Frame's
+  simplified zone-picker entry.
+
+Tests must not freeze pixels, e-ink refresh duration, thread sleeps, or
+incidental internal call sequences. Hardware validation remains separate.
+
+## Migration sequence
+
+1. **This slice:** decision, exact direct-include ratchet, negative fixture, and
+   input/presentation characterization. Keep #190 open.
+2. Introduce renderer-free controller view and command value types behind
+   compatibility adapters.
+3. Characterize and centralize configuration mutations and connectivity events;
+   remove stale whole-struct ownership.
+4. Extract backend transport from the mixed `bridge_client` runtime.
+5. Replace imperative picker queries with semantic navigation/view state.
+6. Let #170 and the server contract own versioned adaptive command payloads.
+
+## Related issue disposition
+
+- #132 and #148 are evidence for scheduler and UI cleanup, not prerequisites or
+  architecture templates.
+- #170 owns versioned adaptive command dispatch.
+- #174 alone owns source-directory moves.
+- #188 supplies the Frame characterization anchor.
+- #191 supplies a shared BLE input consumer.
+- #194 owns configurable action bindings and the eventual separation between
+  physical events and command meaning.
+
+## Consequences
+
+The policy requires an intentional manifest update when a legitimate direct
+edge changes. This is deliberate review friction. It prevents new debt but does
+not pretend existing debt has been removed, and it keeps every intermediate
+step buildable and releasable.

--- a/scripts/check_controller_dependencies.py
+++ b/scripts/check_controller_dependencies.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Fail-closed direct-include policy for the controller boundary.
+
+This intentionally checks source-level quoted includes, not IDF component or
+link dependencies. Dial and Frame are evaluated separately because their CMake
+include order resolves target headers differently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import fnmatch
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_POLICY = ROOT / "scripts" / "controller_dependency_policy.json"
+INCLUDE_RE = re.compile(r'^\s*#\s*include\s+"([^"]+)"', re.MULTILINE)
+ANGLE_INCLUDE_RE = re.compile(r"^\s*#\s*include\s*<([^>]+)>", re.MULTILINE)
+MACRO_INCLUDE_RE = re.compile(
+    r'^\s*#\s*include\s+(?!["<])(?P<value>\S+)', re.MULTILINE
+)
+SRC_FILES_RE = re.compile(
+    r"set\s*\(\s*SRC_FILES(?P<body>.*?)\n\s*\)", re.DOTALL
+)
+COMPONENT_REGISTER_RE = re.compile(
+    r"idf_component_register\s*\((?P<body>.*?)\n\s*\)", re.DOTALL
+)
+SET_PROPERTY_RE = re.compile(
+    r"set_property\s*\((?P<body>.*?)\)", re.DOTALL
+)
+QUOTED_VALUE_RE = re.compile(r'"([^"]+)"')
+PROJECT_INCLUDE_SUFFIXES = {".h", ".hh", ".hpp", ".inc"}
+SOURCE_SUFFIXES = {".c", ".cc", ".cpp"}
+SOURCE_TOKEN_RE = re.compile(
+    r'(?:"[^"]+"|[A-Za-z0-9_./${}-]+)\.(?:c|cc|cpp|s|S)\b'
+)
+CMAKE_COMMAND_RE = re.compile(
+    r"(?m)^\s*(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\("
+)
+SUPPORTED_CMAKE_COMMANDS = {
+    "idf_component_register",
+    "set",
+    "set_property",
+    "target_compile_definitions",
+    "target_compile_options",
+}
+SUPPORTED_SET_PROPERTIES = {
+    "DIRECTORY PROPERTY CMAKE_SUPPRESS_DEVELOPER_WARNINGS ON",
+    "TARGET ${COMPONENT_LIB} PROPERTY C_STANDARD 11",
+}
+
+
+@dataclass(frozen=True, order=True)
+class Edge:
+    target: str
+    source: str
+    header: str
+
+    @property
+    def key(self) -> str:
+        return f"{self.target}|{self.source}|{self.header}"
+
+
+def relative_path(path: Path, root: Path = ROOT) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def parse_cmake_sources(cmake_path: Path) -> list[Path]:
+    text = cmake_path.read_text(encoding="utf-8")
+    uncommented = re.sub(r"#.*$", "", text, flags=re.MULTILINE)
+    command_names = CMAKE_COMMAND_RE.findall(uncommented)
+    unsupported_commands = sorted(
+        {
+            name
+            for name in command_names
+            if name.lower() not in SUPPORTED_CMAKE_COMMANDS
+        }
+    )
+    if unsupported_commands:
+        raise ValueError(
+            f"{relative_path(cmake_path)}: unsupported CMake command(s): "
+            + ", ".join(unsupported_commands)
+        )
+    if sum(name.lower() == "set" for name in command_names) != 1:
+        raise ValueError(
+            f"{relative_path(cmake_path)}: only the literal SRC_FILES set is supported"
+        )
+    observed_properties = {
+        " ".join(match.group("body").split())
+        for match in SET_PROPERTY_RE.finditer(uncommented)
+    }
+    if (
+        len(observed_properties)
+        != sum(name.lower() == "set_property" for name in command_names)
+        or not observed_properties.issubset(SUPPORTED_SET_PROPERTIES)
+    ):
+        raise ValueError(
+            f"{relative_path(cmake_path)}: unsupported set_property form"
+        )
+    matches = list(SRC_FILES_RE.finditer(uncommented))
+    location = relative_path(cmake_path)
+    if len(matches) != 1:
+        raise ValueError(
+            f"{location}: expected exactly one literal set(SRC_FILES ...)"
+        )
+    match = matches[0]
+    registrations = list(COMPONENT_REGISTER_RE.finditer(uncommented))
+    registration_body = (
+        registrations[0].group("body") if len(registrations) == 1 else ""
+    )
+    if (
+        uncommented.count("SRC_FILES") != 2
+        or len(registrations) != 1
+        or not re.search(
+            r"\bSRCS\s+\$\{SRC_FILES\}\s+(?:INCLUDE_DIRS\b|$)",
+            registration_body,
+            re.DOTALL,
+        )
+        or re.search(r"\b(?:SRC_DIRS|EXCLUDE_SRCS)\b", registration_body)
+    ):
+        raise ValueError(
+            f"{location}: unsupported SRC_FILES mutation or component registration"
+        )
+    outside_inventory = (
+        uncommented[: match.start()]
+        + uncommented[match.end() : registrations[0].start()]
+        + uncommented[registrations[0].end() :]
+    )
+    if re.search(r"\btarget_sources\s*\(", outside_inventory):
+        raise ValueError(f"{location}: target_sources is outside the enforced contract")
+    extra_source = SOURCE_TOKEN_RE.search(
+        registration_body.replace("${SRC_FILES}", "")
+        + outside_inventory
+    )
+    if extra_source:
+        raise ValueError(
+            f"{location}: source outside literal SRC_FILES: {extra_source.group(0)}"
+        )
+    unparsed = QUOTED_VALUE_RE.sub("", match.group("body")).strip()
+    if unparsed:
+        raise ValueError(
+            f"{location}: SRC_FILES entries must be literal quoted paths: {unparsed}"
+        )
+
+    sources: list[Path] = []
+    for value in QUOTED_VALUE_RE.findall(match.group("body")):
+        source = (cmake_path.parent / value).resolve()
+        if source.suffix not in SOURCE_SUFFIXES:
+            raise ValueError(f"{location}: unsupported source type: {value}")
+        sources.append(source)
+    return sources
+
+
+def project_file_index(root: Path = ROOT) -> dict[str, list[Path]]:
+    index: dict[str, list[Path]] = {}
+    ignored_parts = {".git", "build", "managed_components"}
+    for candidate in root.rglob("*"):
+        if not candidate.is_file():
+            continue
+        if ignored_parts.intersection(candidate.relative_to(root).parts):
+            continue
+        index.setdefault(candidate.name, []).append(candidate.resolve())
+    return index
+
+
+def normalize_preprocessor_text(text: str) -> str:
+    text = text.replace("\\\r\n", "").replace("\\\n", "")
+
+    def replace(match: re.Match[str]) -> str:
+        return " " + ("\n" * match.group(0).count("\n"))
+
+    return re.sub(r"/\*.*?\*/", replace, text, flags=re.DOTALL)
+
+
+def resolve_header(
+    include: str,
+    source: Path,
+    include_dirs: Iterable[Path],
+    index: dict[str, list[Path]],
+) -> Path | None:
+    candidates = [source.parent / include]
+    candidates.extend(directory / include for directory in include_dirs)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    return None
+
+
+def collect_edges(
+    policy: dict,
+    root: Path = ROOT,
+    extra_sources: dict[str, list[Path]] | None = None,
+) -> set[Edge]:
+    index = project_file_index(root)
+    observed: set[Edge] = set()
+
+    for target_name, target in policy["targets"].items():
+        cmake_path = root / target["cmake"]
+        include_dirs = [(root / path).resolve() for path in target["include_dirs"]]
+        pending = list(parse_cmake_sources(cmake_path))
+        if extra_sources:
+            pending.extend(extra_sources.get(target_name, []))
+        visited: set[Path] = set()
+        while pending:
+            source = pending.pop()
+            if source in visited:
+                continue
+            visited.add(source)
+            if not source.is_file():
+                raise ValueError(
+                    f"{target_name}: configured source is missing: "
+                    f"{relative_path(source, root)}"
+                )
+            source_text = normalize_preprocessor_text(
+                source.read_text(encoding="utf-8")
+            )
+            macro_includes = MACRO_INCLUDE_RE.findall(source_text)
+            if macro_includes:
+                raise ValueError(
+                    f"{relative_path(source, root)}: macro include is outside "
+                    f"the enforced contract: {macro_includes[0]}"
+                )
+            for include in ANGLE_INCLUDE_RE.findall(source_text):
+                if Path(include).name in index:
+                    raise ValueError(
+                        f"{relative_path(source, root)}: repository-local angle "
+                        f"include is outside the enforced contract: {include}"
+                    )
+            for include in INCLUDE_RE.findall(source_text):
+                resolved = resolve_header(include, source, include_dirs, index)
+                if resolved is None:
+                    if Path(include).name in index:
+                        raise ValueError(
+                            f"{relative_path(source, root)}: unresolved or "
+                            f"unreachable repository include: {include}"
+                        )
+                    continue
+                if resolved.suffix in PROJECT_INCLUDE_SUFFIXES and resolved not in visited:
+                    pending.append(resolved)
+                header = relative_path(resolved, root)
+                observed.add(
+                    Edge(
+                        target=target_name,
+                        source=relative_path(source, root),
+                        header=header,
+                    )
+                )
+    return observed
+
+
+def edge_from_key(key: str) -> Edge:
+    parts = key.split("|")
+    if len(parts) != 3 or not all(parts):
+        raise ValueError(f"invalid edge key: {key}")
+    return Edge(*parts)
+
+
+def expected_edges(policy: dict) -> set[Edge]:
+    expected = {edge_from_key(key) for key in policy["expected_edges"]}
+    if len(expected) != len(policy["expected_edges"]):
+        raise ValueError("duplicate expected edge")
+    return expected
+
+
+def grandfathered_edges(policy: dict) -> dict[Edge, dict]:
+    grandfathered: dict[Edge, dict] = {}
+    expected = expected_edges(policy)
+    for item in policy["grandfathered_edges"]:
+        edge = edge_from_key(item["edge"])
+        if edge in grandfathered:
+            raise ValueError(f"duplicate grandfathered edge: {edge.key}")
+        if edge not in expected:
+            raise ValueError(f"grandfathered edge is not expected: {edge.key}")
+        for field in ("owner", "retirement_issue", "reason"):
+            if not item.get(field):
+                raise ValueError(f"{edge.key}: {field} is required")
+        grandfathered[edge] = item
+    return grandfathered
+
+
+def forbidden_rules_for(edge: Edge, policy: dict) -> list[str]:
+    matches: list[str] = []
+    for rule in policy["forbidden_rules"]:
+        if any(
+            fnmatch.fnmatchcase(edge.source, pattern)
+            for pattern in rule["source_patterns"]
+        ) and any(
+            fnmatch.fnmatchcase(edge.header, pattern)
+            for pattern in rule["header_patterns"]
+        ):
+            matches.append(rule["name"])
+    return matches
+
+
+def validate(policy: dict, observed: set[Edge]) -> list[str]:
+    expected = expected_edges(policy)
+    grandfathered = grandfathered_edges(policy)
+    errors: list[str] = []
+
+    rule_names = [rule["name"] for rule in policy["forbidden_rules"]]
+    if len(set(rule_names)) != len(rule_names):
+        errors.append("duplicate forbidden rule name")
+
+    for edge in sorted(observed - expected):
+        errors.append(f"unlisted restricted edge: {edge.key}")
+    for edge in sorted(expected - observed):
+        errors.append(f"stale policy edge: {edge.key}")
+    for edge in sorted(expected):
+        forbidden = forbidden_rules_for(edge, policy)
+        if forbidden and edge not in grandfathered:
+            errors.append(
+                f"forbidden edge lacks ownership metadata ({','.join(forbidden)}): "
+                f"{edge.key}"
+            )
+        if not forbidden and edge in grandfathered:
+            errors.append(
+                f"grandfathered edge matches no forbidden rule: {edge.key}"
+            )
+    return errors
+
+
+def print_edges(edges: Iterable[Edge]) -> None:
+    for edge in sorted(edges):
+        print(edge.key)
+
+
+def run_negative_fixture(policy: dict) -> None:
+    target = policy["negative_fixture"]["target"]
+    source = ROOT / policy["negative_fixture"]["source"]
+    expected_header = policy["negative_fixture"]["header"]
+    expected_fixture = Edge(
+        target=target,
+        source=relative_path(source),
+        header=expected_header,
+    )
+    production_edges = collect_edges(policy)
+    fixture_edges = collect_edges(policy, extra_sources={target: [source]})
+    if expected_fixture not in fixture_edges:
+        raise AssertionError(
+            f"negative fixture resolved {sorted(edge.key for edge in fixture_edges)}, "
+            f"expected {expected_fixture.key}"
+        )
+
+    errors = validate(policy, fixture_edges)
+    expected_error = f"unlisted restricted edge: {expected_fixture.key}"
+    if expected_error not in errors:
+        raise AssertionError(
+            "negative fixture was not rejected with the expected edge: "
+            + "; ".join(errors)
+        )
+
+    ownerless_policy = copy.deepcopy(policy)
+    ownerless_policy["expected_edges"].append(expected_fixture.key)
+    ownerless_errors = validate(ownerless_policy, production_edges | {expected_fixture})
+    if not any(
+        error.startswith("forbidden edge lacks ownership metadata")
+        and error.endswith(expected_fixture.key)
+        for error in ownerless_errors
+    ):
+        raise AssertionError(
+            "negative fixture could be classified as allowed without ownership: "
+            + "; ".join(ownerless_errors)
+        )
+
+    for fixture_path in policy["negative_fixture"]["unsupported_cmake"]:
+        unsupported_cmake = ROOT / fixture_path
+        try:
+            parse_cmake_sources(unsupported_cmake)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(
+                f"unsupported CMake source mutation was accepted: {fixture_path}"
+            )
+    print("controller dependency negative fixture passed")
+
+
+def load_policy(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy", type=Path, default=DEFAULT_POLICY)
+    parser.add_argument("--dump", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+
+    try:
+        policy = load_policy(args.policy)
+        observed = collect_edges(policy)
+        if args.dump:
+            print_edges(observed)
+            return 0
+        if args.self_test:
+            run_negative_fixture(policy)
+            return 0
+
+        errors = validate(policy, observed)
+        if errors:
+            for error in errors:
+                print(error, file=sys.stderr)
+            return 1
+        grandfathered = len(grandfathered_edges(policy))
+        allowed = len(policy["expected_edges"]) - grandfathered
+        print(
+            "controller dependency policy passed: "
+            f"{allowed} allowed, {grandfathered} grandfathered"
+        )
+        return 0
+    except (OSError, ValueError, KeyError, json.JSONDecodeError, AssertionError) as err:
+        print(f"controller dependency policy error: {err}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/controller_dependency_policy.json
+++ b/scripts/controller_dependency_policy.json
@@ -1,0 +1,502 @@
+{
+  "schema_version": 2,
+  "targets": {
+    "dial": {
+      "cmake": "idf_app/main/CMakeLists.txt",
+      "include_dirs": [
+        "idf_app/main",
+        "idf_app/components/i2c_bsp",
+        "idf_app/components/lcd_touch_bsp",
+        "include",
+        "common",
+        "components/rk_ble_hid_host/include",
+        "components/rk_ble_hid_host"
+      ]
+    },
+    "frame": {
+      "cmake": "frame_app/main/CMakeLists.txt",
+      "include_dirs": [
+        "frame_app/main",
+        "include",
+        "common",
+        "components/rk_ble_hid_host/include",
+        "components/rk_ble_hid_host"
+      ]
+    }
+  },
+  "negative_fixture": {
+    "target": "dial",
+    "source": "tests/fixtures/controller_dependency/common/new_controller.c",
+    "header": "tests/fixtures/controller_dependency/idf_app/main/new_target_ui.h",
+    "unsupported_cmake": [
+      "tests/fixtures/controller_dependency/unsupported_sources.cmake",
+      "tests/fixtures/controller_dependency/inline_source.cmake",
+      "tests/fixtures/controller_dependency/target_sources.cmake",
+      "tests/fixtures/controller_dependency/add_subdirectory.cmake",
+      "tests/fixtures/controller_dependency/include_sources.cmake",
+      "tests/fixtures/controller_dependency/composed_property_source.cmake",
+      "tests/fixtures/controller_dependency/src_dirs.cmake"
+    ]
+  },
+  "expected_edges": [
+    "dial|common/app_main.c|common/app.h",
+    "dial|common/app_main.c|common/bridge_client.h",
+    "dial|common/app_main.c|common/controller_input.h",
+    "dial|common/app_main.c|common/platform/platform_log.h",
+    "dial|common/app_main.c|common/platform/platform_mdns.h",
+    "dial|common/app_main.c|common/platform/platform_storage.h",
+    "dial|common/app_main.c|common/rk_cfg.h",
+    "dial|common/bridge_client.c|common/bridge_client.h",
+    "dial|common/bridge_client.c|common/controller_input.h",
+    "dial|common/bridge_client.c|common/controller_presentation.h",
+    "dial|common/bridge_client.c|common/platform/platform_display.h",
+    "dial|common/bridge_client.c|common/platform/platform_http.h",
+    "dial|common/bridge_client.c|common/platform/platform_log.h",
+    "dial|common/bridge_client.c|common/platform/platform_mdns.h",
+    "dial|common/bridge_client.c|common/platform/platform_storage.h",
+    "dial|common/bridge_client.c|common/platform/platform_task.h",
+    "dial|common/bridge_client.c|common/platform/platform_time.h",
+    "dial|common/bridge_client.c|include/os_mutex.h",
+    "dial|common/bridge_client.h|common/controller_input.h",
+    "dial|common/bridge_client.h|common/rk_cfg.h",
+    "dial|common/controller_ble_input.c|common/controller_ble_input.h",
+    "dial|common/controller_ble_input.c|common/controller_input.h",
+    "dial|common/controller_ble_input.h|components/rk_ble_hid_host/include/rk_ble_hid_host.h",
+    "dial|common/controller_input.c|common/controller_input.h",
+    "dial|common/controller_input.c|common/platform/platform_task.h",
+    "dial|common/platform/platform_display.h|common/rk_cfg.h",
+    "dial|common/platform/platform_log.c|common/platform/platform_log.h",
+    "dial|common/platform/platform_storage.h|common/rk_cfg.h",
+    "dial|common/platform/platform_task.c|common/platform/platform_task.h",
+    "dial|common/platform/platform_task.c|include/os_mutex.h",
+    "dial|common/platform/platform_task.h|include/os_thread.h",
+    "dial|common/platform/platform_time.c|common/platform/platform_time.h",
+    "dial|common/platform/platform_time.c|include/os_time.h",
+    "dial|common/ui.c|common/bridge_client.h",
+    "dial|common/ui.c|common/controller_input.h",
+    "dial|common/ui.c|common/platform/platform_http.h",
+    "dial|common/ui.c|common/platform/platform_task.h",
+    "dial|common/ui.c|common/platform/platform_time.h",
+    "dial|common/ui.c|common/ui.h",
+    "dial|common/ui.c|common/ui_jpeg.h",
+    "dial|common/ui.c|idf_app/main/battery.h",
+    "dial|common/ui.c|idf_app/main/font_manager.h",
+    "dial|common/ui.c|idf_app/main/ota_update.h",
+    "dial|common/ui.c|include/os_mutex.h",
+    "dial|common/ui_jpeg.c|common/ui_jpeg.h",
+    "dial|common/wifi_manager.c|common/platform/platform_identity.h",
+    "dial|common/wifi_manager.c|common/platform/platform_storage.h",
+    "dial|common/wifi_manager.c|common/wifi_manager.h",
+    "dial|common/wifi_manager.c|idf_app/main/captive_portal.h",
+    "dial|common/wifi_manager.h|common/rk_cfg.h",
+    "dial|idf_app/main/battery.c|common/platform/platform_time.h",
+    "dial|idf_app/main/battery.c|idf_app/main/battery.h",
+    "dial|idf_app/main/ble_hid_host_dial.c|common/controller_ble_input.h",
+    "dial|idf_app/main/ble_hid_host_dial.c|common/platform/platform_task.h",
+    "dial|idf_app/main/ble_hid_host_dial.c|components/rk_ble_hid_host/include/rk_ble_hid_host.h",
+    "dial|idf_app/main/ble_hid_host_dial.c|idf_app/main/ble_hid_host_dial.h",
+    "dial|idf_app/main/ble_hid_host_dial.c|idf_app/main/ui_network.h",
+    "dial|idf_app/main/captive_portal.c|common/platform/platform_storage.h",
+    "dial|idf_app/main/captive_portal.c|common/ui.h",
+    "dial|idf_app/main/captive_portal.c|common/wifi_manager.h",
+    "dial|idf_app/main/captive_portal.c|idf_app/main/captive_portal.h",
+    "dial|idf_app/main/captive_portal.c|idf_app/main/dns_server.h",
+    "dial|idf_app/main/config_server.c|common/bridge_client.h",
+    "dial|idf_app/main/config_server.c|common/platform/platform_mdns.h",
+    "dial|idf_app/main/config_server.c|common/platform/platform_storage.h",
+    "dial|idf_app/main/config_server.c|common/wifi_manager.h",
+    "dial|idf_app/main/config_server.c|components/rk_ble_hid_host/include/rk_ble_hid_host.h",
+    "dial|idf_app/main/config_server.c|idf_app/main/config_server.h",
+    "dial|idf_app/main/controller_presentation_dial.c|common/controller_presentation.h",
+    "dial|idf_app/main/controller_presentation_dial.c|common/ui.h",
+    "dial|idf_app/main/display_sleep.c|common/bridge_client.h",
+    "dial|idf_app/main/display_sleep.c|common/platform/platform_display.h",
+    "dial|idf_app/main/display_sleep.c|common/ui.h",
+    "dial|idf_app/main/display_sleep.c|common/wifi_manager.h",
+    "dial|idf_app/main/display_sleep.c|idf_app/main/battery.h",
+    "dial|idf_app/main/display_sleep.c|idf_app/main/captive_portal.h",
+    "dial|idf_app/main/display_sleep.c|idf_app/main/display_sleep.h",
+    "dial|idf_app/main/display_sleep.h|common/rk_cfg.h",
+    "dial|idf_app/main/dns_server.c|idf_app/main/dns_server.h",
+    "dial|idf_app/main/font_manager.c|idf_app/main/font_manager.h",
+    "dial|idf_app/main/main_idf.c|common/app.h",
+    "dial|idf_app/main/main_idf.c|common/bridge_client.h",
+    "dial|idf_app/main/main_idf.c|common/platform/platform_http.h",
+    "dial|idf_app/main/main_idf.c|common/platform/platform_input.h",
+    "dial|idf_app/main/main_idf.c|common/platform/platform_mdns.h",
+    "dial|idf_app/main/main_idf.c|common/platform/platform_storage.h",
+    "dial|idf_app/main/main_idf.c|common/platform/platform_time.h",
+    "dial|idf_app/main/main_idf.c|common/ui.h",
+    "dial|idf_app/main/main_idf.c|common/wifi_manager.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/battery.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/ble_hid_host_dial.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/config_server.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/display_sleep.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/font_manager.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/ota_update.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/platform_display_idf.h",
+    "dial|idf_app/main/main_idf.c|idf_app/main/ui_network.h",
+    "dial|idf_app/main/ota_update.c|common/platform/platform_storage.h",
+    "dial|idf_app/main/ota_update.c|idf_app/main/ota_update.h",
+    "dial|idf_app/main/platform_display_idf.c|common/bridge_client.h",
+    "dial|idf_app/main/platform_display_idf.c|common/platform/platform_display.h",
+    "dial|idf_app/main/platform_display_idf.c|idf_app/components/i2c_bsp/i2c_bsp.h",
+    "dial|idf_app/main/platform_display_idf.c|idf_app/components/lcd_touch_bsp/lcd_touch_bsp.h",
+    "dial|idf_app/main/platform_display_idf.c|idf_app/main/battery.h",
+    "dial|idf_app/main/platform_display_idf.c|idf_app/main/display_sleep.h",
+    "dial|idf_app/main/platform_display_idf.c|idf_app/main/platform_display_idf.h",
+    "dial|idf_app/main/platform_http_idf.c|common/platform/platform_http.h",
+    "dial|idf_app/main/platform_identity_idf.c|common/platform/platform_identity.h",
+    "dial|idf_app/main/platform_input_idf.c|common/controller_input.h",
+    "dial|idf_app/main/platform_input_idf.c|common/platform/platform_input.h",
+    "dial|idf_app/main/platform_input_idf.c|idf_app/main/display_sleep.h",
+    "dial|idf_app/main/platform_log_idf.c|common/platform/platform_log.h",
+    "dial|idf_app/main/platform_mdns_idf.c|common/platform/platform_mdns.h",
+    "dial|idf_app/main/platform_storage_idf.c|common/platform/platform_storage.h",
+    "dial|idf_app/main/ui_network.c|common/bridge_client.h",
+    "dial|idf_app/main/ui_network.c|common/platform/platform_http.h",
+    "dial|idf_app/main/ui_network.c|common/platform/platform_storage.h",
+    "dial|idf_app/main/ui_network.c|common/ui.h",
+    "dial|idf_app/main/ui_network.c|common/wifi_manager.h",
+    "dial|idf_app/main/ui_network.c|idf_app/main/font_manager.h",
+    "dial|idf_app/main/ui_network.c|idf_app/main/ota_update.h",
+    "dial|idf_app/main/ui_network.c|idf_app/main/ui_network.h",
+    "dial|idf_app/main/ui_network.h|common/wifi_manager.h",
+    "frame|common/app_main.c|common/app.h",
+    "frame|common/app_main.c|common/bridge_client.h",
+    "frame|common/app_main.c|common/controller_input.h",
+    "frame|common/app_main.c|common/platform/platform_log.h",
+    "frame|common/app_main.c|common/platform/platform_mdns.h",
+    "frame|common/app_main.c|common/platform/platform_storage.h",
+    "frame|common/app_main.c|common/rk_cfg.h",
+    "frame|common/bridge_client.c|common/bridge_client.h",
+    "frame|common/bridge_client.c|common/controller_input.h",
+    "frame|common/bridge_client.c|common/controller_presentation.h",
+    "frame|common/bridge_client.c|common/platform/platform_display.h",
+    "frame|common/bridge_client.c|common/platform/platform_http.h",
+    "frame|common/bridge_client.c|common/platform/platform_log.h",
+    "frame|common/bridge_client.c|common/platform/platform_mdns.h",
+    "frame|common/bridge_client.c|common/platform/platform_storage.h",
+    "frame|common/bridge_client.c|common/platform/platform_task.h",
+    "frame|common/bridge_client.c|common/platform/platform_time.h",
+    "frame|common/bridge_client.c|include/os_mutex.h",
+    "frame|common/bridge_client.h|common/controller_input.h",
+    "frame|common/bridge_client.h|common/rk_cfg.h",
+    "frame|common/controller_ble_input.c|common/controller_ble_input.h",
+    "frame|common/controller_ble_input.c|common/controller_input.h",
+    "frame|common/controller_ble_input.h|components/rk_ble_hid_host/include/rk_ble_hid_host.h",
+    "frame|common/controller_input.c|common/controller_input.h",
+    "frame|common/controller_input.c|common/platform/platform_task.h",
+    "frame|common/platform/platform_display.h|common/rk_cfg.h",
+    "frame|common/platform/platform_log.c|common/platform/platform_log.h",
+    "frame|common/platform/platform_storage.h|common/rk_cfg.h",
+    "frame|common/platform/platform_task.c|common/platform/platform_task.h",
+    "frame|common/platform/platform_task.c|include/os_mutex.h",
+    "frame|common/platform/platform_task.h|include/os_thread.h",
+    "frame|common/platform/platform_time.c|common/platform/platform_time.h",
+    "frame|common/platform/platform_time.c|include/os_time.h",
+    "frame|common/wifi_manager.c|common/platform/platform_identity.h",
+    "frame|common/wifi_manager.c|common/platform/platform_storage.h",
+    "frame|common/wifi_manager.c|common/wifi_manager.h",
+    "frame|common/wifi_manager.c|frame_app/main/captive_portal.h",
+    "frame|common/wifi_manager.h|common/rk_cfg.h",
+    "frame|frame_app/main/ble_hid_host_frame.c|common/controller_ble_input.h",
+    "frame|frame_app/main/ble_hid_host_frame.c|common/platform/platform_task.h",
+    "frame|frame_app/main/ble_hid_host_frame.c|components/rk_ble_hid_host/include/rk_ble_hid_host.h",
+    "frame|frame_app/main/ble_hid_host_frame.c|frame_app/main/ble_hid_host_frame.h",
+    "frame|frame_app/main/ble_hid_host_frame.c|frame_app/main/eink_ui.h",
+    "frame|frame_app/main/captive_portal.c|common/bridge_client.h",
+    "frame|frame_app/main/captive_portal.c|common/platform/platform_storage.h",
+    "frame|frame_app/main/captive_portal.c|common/rk_cfg.h",
+    "frame|frame_app/main/captive_portal.c|common/wifi_manager.h",
+    "frame|frame_app/main/captive_portal.c|components/rk_ble_hid_host/include/rk_ble_hid_host.h",
+    "frame|frame_app/main/captive_portal.c|frame_app/main/captive_portal.h",
+    "frame|frame_app/main/captive_portal.c|frame_app/main/dns_server.h",
+    "frame|frame_app/main/captive_portal.c|frame_app/main/eink_ui.h",
+    "frame|frame_app/main/controller_presentation_frame.c|common/controller_presentation.h",
+    "frame|frame_app/main/controller_presentation_frame.c|frame_app/main/eink_ui.h",
+    "frame|frame_app/main/dns_server.c|frame_app/main/dns_server.h",
+    "frame|frame_app/main/eink_display.c|frame_app/main/eink_display.h",
+    "frame|frame_app/main/eink_dither.c|frame_app/main/eink_dither.h",
+    "frame|frame_app/main/eink_font.c|frame_app/main/eink_display.h",
+    "frame|frame_app/main/eink_font.c|frame_app/main/eink_font.h",
+    "frame|frame_app/main/eink_ui.c|common/bridge_client.h",
+    "frame|frame_app/main/eink_ui.c|common/platform/platform_http.h",
+    "frame|frame_app/main/eink_ui.c|common/platform/platform_log.h",
+    "frame|frame_app/main/eink_ui.c|common/platform/platform_task.h",
+    "frame|frame_app/main/eink_ui.c|common/platform/platform_time.h",
+    "frame|frame_app/main/eink_ui.c|frame_app/main/eink_display.h",
+    "frame|frame_app/main/eink_ui.c|frame_app/main/eink_dither.h",
+    "frame|frame_app/main/eink_ui.c|frame_app/main/eink_font.h",
+    "frame|frame_app/main/eink_ui.c|frame_app/main/eink_ui.h",
+    "frame|frame_app/main/main_frame.c|common/app.h",
+    "frame|frame_app/main/main_frame.c|common/bridge_client.h",
+    "frame|frame_app/main/main_frame.c|common/platform/platform_http.h",
+    "frame|frame_app/main/main_frame.c|common/platform/platform_input.h",
+    "frame|frame_app/main/main_frame.c|common/platform/platform_mdns.h",
+    "frame|frame_app/main/main_frame.c|common/platform/platform_storage.h",
+    "frame|frame_app/main/main_frame.c|common/platform/platform_task.h",
+    "frame|frame_app/main/main_frame.c|common/platform/platform_time.h",
+    "frame|frame_app/main/main_frame.c|common/wifi_manager.h",
+    "frame|frame_app/main/main_frame.c|frame_app/main/ble_hid_host_frame.h",
+    "frame|frame_app/main/main_frame.c|frame_app/main/captive_portal.h",
+    "frame|frame_app/main/main_frame.c|frame_app/main/eink_display.h",
+    "frame|frame_app/main/main_frame.c|frame_app/main/eink_ui.h",
+    "frame|frame_app/main/main_frame.c|frame_app/main/pmic_axp2101.h",
+    "frame|frame_app/main/platform_display_frame.c|common/platform/platform_display.h",
+    "frame|frame_app/main/platform_display_frame.c|frame_app/main/pmic_axp2101.h",
+    "frame|frame_app/main/platform_http_frame.c|common/platform/platform_http.h",
+    "frame|frame_app/main/platform_identity_frame.c|common/platform/platform_identity.h",
+    "frame|frame_app/main/platform_input_frame.c|common/platform/platform_input.h",
+    "frame|frame_app/main/platform_input_frame.c|common/wifi_manager.h",
+    "frame|frame_app/main/platform_log_frame.c|common/platform/platform_log.h",
+    "frame|frame_app/main/platform_mdns_frame.c|common/platform/platform_mdns.h",
+    "frame|frame_app/main/platform_storage_frame.c|common/platform/platform_storage.h",
+    "frame|frame_app/main/platform_storage_frame.c|common/rk_cfg.h",
+    "frame|frame_app/main/pmic_axp2101.c|frame_app/main/pmic_axp2101.h"
+  ],
+  "grandfathered_edges": [
+    {
+      "edge": "dial|common/ui.c|common/bridge_client.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#132",
+      "reason": "Legacy Dial renderer still queries controller state directly."
+    },
+    {
+      "edge": "dial|common/ui.c|idf_app/main/battery.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#132",
+      "reason": "Shared legacy Dial renderer reaches into a target-only battery API."
+    },
+    {
+      "edge": "dial|common/ui.c|idf_app/main/ota_update.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#170",
+      "reason": "Shared legacy Dial renderer reaches into a target-only OTA API."
+    },
+    {
+      "edge": "dial|common/wifi_manager.c|idf_app/main/captive_portal.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Shared connectivity code directly selects the Dial provisioning UI."
+    },
+    {
+      "edge": "dial|idf_app/main/ble_hid_host_dial.c|idf_app/main/ui_network.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#191",
+      "reason": "BLE target adapter directly refreshes the Dial network UI."
+    },
+    {
+      "edge": "dial|idf_app/main/captive_portal.c|common/ui.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Dial provisioning adapter directly controls the legacy renderer."
+    },
+    {
+      "edge": "dial|idf_app/main/display_sleep.c|common/bridge_client.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Dial sleep policy reads controller state through the mixed bridge client."
+    },
+    {
+      "edge": "dial|idf_app/main/display_sleep.c|common/ui.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Dial sleep policy directly controls the legacy renderer."
+    },
+    {
+      "edge": "dial|idf_app/main/display_sleep.c|common/wifi_manager.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#194",
+      "reason": "Dial sleep policy is coupled directly to connectivity state."
+    },
+    {
+      "edge": "dial|idf_app/main/display_sleep.c|idf_app/main/captive_portal.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#194",
+      "reason": "Dial sleep policy is coupled directly to provisioning state."
+    },
+    {
+      "edge": "dial|idf_app/main/platform_display_idf.c|common/bridge_client.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Dial display adapter queries the mixed controller client instead of consuming presentation state."
+    },
+    {
+      "edge": "dial|idf_app/main/platform_display_idf.c|idf_app/main/display_sleep.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#194",
+      "reason": "Dial display adapter owns peer sleep-policy transitions as well as rendering."
+    },
+    {
+      "edge": "dial|idf_app/main/platform_input_idf.c|idf_app/main/display_sleep.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#194",
+      "reason": "Dial input adapter owns display wake behavior as well as input translation."
+    },
+    {
+      "edge": "dial|idf_app/main/ui_network.c|common/bridge_client.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Dial network renderer queries the mixed controller client directly."
+    },
+    {
+      "edge": "dial|idf_app/main/ui_network.c|common/ui.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Dial network renderer is coupled to the legacy UI implementation."
+    },
+    {
+      "edge": "dial|idf_app/main/ui_network.c|common/wifi_manager.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#170",
+      "reason": "Dial network renderer queries connectivity state directly."
+    },
+    {
+      "edge": "dial|idf_app/main/ui_network.c|idf_app/main/ota_update.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#170",
+      "reason": "Dial network renderer queries OTA state directly."
+    },
+    {
+      "edge": "dial|idf_app/main/ui_network.h|common/wifi_manager.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "A target UI header exposes a connectivity implementation type."
+    },
+    {
+      "edge": "frame|common/wifi_manager.c|frame_app/main/captive_portal.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Shared connectivity code directly selects the Frame provisioning UI."
+    },
+    {
+      "edge": "frame|frame_app/main/ble_hid_host_frame.c|frame_app/main/eink_ui.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#191",
+      "reason": "BLE target adapter directly refreshes the Frame renderer."
+    },
+    {
+      "edge": "frame|frame_app/main/captive_portal.c|common/bridge_client.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Frame provisioning adapter queries the mixed controller client directly."
+    },
+    {
+      "edge": "frame|frame_app/main/captive_portal.c|frame_app/main/eink_ui.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Frame provisioning adapter directly controls the Frame renderer."
+    },
+    {
+      "edge": "frame|frame_app/main/eink_ui.c|common/bridge_client.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#190",
+      "reason": "Frame renderer queries the mixed controller client directly."
+    },
+    {
+      "edge": "frame|frame_app/main/platform_input_frame.c|common/wifi_manager.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#194",
+      "reason": "Frame input adapter owns provisioning state transitions as well as input translation."
+    },
+    {
+      "edge": "dial|common/ui.c|idf_app/main/font_manager.h",
+      "owner": "controller architecture program",
+      "retirement_issue": "#132",
+      "reason": "Shared legacy Dial renderer reaches into a target-only font implementation."
+    }
+  ],
+  "forbidden_rules": [
+    {
+      "name": "shared_code_must_not_include_target_implementation",
+      "source_patterns": [
+        "common/**"
+      ],
+      "header_patterns": [
+        "idf_app/**",
+        "frame_app/**"
+      ]
+    },
+    {
+      "name": "renderer_must_not_query_controller_or_connectivity",
+      "source_patterns": [
+        "common/ui.c",
+        "idf_app/main/ui_network.c",
+        "idf_app/main/ui_network.h",
+        "frame_app/main/eink_ui.c"
+      ],
+      "header_patterns": [
+        "common/bridge_client.h",
+        "common/wifi_manager.h",
+        "idf_app/main/ota_update.h"
+      ]
+    },
+    {
+      "name": "target_renderer_must_not_include_legacy_renderer",
+      "source_patterns": [
+        "idf_app/main/ui_network.c"
+      ],
+      "header_patterns": [
+        "common/ui.h"
+      ]
+    },
+    {
+      "name": "target_adapter_must_not_control_renderer",
+      "source_patterns": [
+        "idf_app/main/ble_hid_host_dial.c",
+        "idf_app/main/captive_portal.c",
+        "idf_app/main/display_sleep.c",
+        "frame_app/main/ble_hid_host_frame.c",
+        "frame_app/main/captive_portal.c"
+      ],
+      "header_patterns": [
+        "common/ui.h",
+        "idf_app/main/ui_network.h",
+        "frame_app/main/eink_ui.h"
+      ]
+    },
+    {
+      "name": "sleep_policy_must_not_own_controller_connectivity_or_provisioning",
+      "source_patterns": [
+        "idf_app/main/display_sleep.c"
+      ],
+      "header_patterns": [
+        "common/bridge_client.h",
+        "common/wifi_manager.h",
+        "idf_app/main/captive_portal.h"
+      ]
+    },
+    {
+      "name": "hardware_adapter_must_not_own_controller_or_peer_policy",
+      "source_patterns": [
+        "idf_app/main/platform_display_idf.c",
+        "idf_app/main/platform_input_idf.c",
+        "frame_app/main/platform_input_frame.c"
+      ],
+      "header_patterns": [
+        "common/bridge_client.h",
+        "common/wifi_manager.h",
+        "idf_app/main/display_sleep.h"
+      ]
+    },
+    {
+      "name": "provisioning_adapter_must_not_query_controller",
+      "source_patterns": [
+        "frame_app/main/captive_portal.c"
+      ],
+      "header_patterns": [
+        "common/bridge_client.h"
+      ]
+    },
+    {
+      "name": "negative_fixture_shared_code_must_not_include_target_ui",
+      "source_patterns": [
+        "tests/fixtures/controller_dependency/common/**"
+      ],
+      "header_patterns": [
+        "tests/fixtures/controller_dependency/idf_app/**"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/controller_dependency/add_subdirectory.cmake
+++ b/tests/fixtures/controller_dependency/add_subdirectory.cmake
@@ -1,0 +1,9 @@
+set(SRC_FILES
+    "first.c"
+)
+
+idf_component_register(
+    SRCS ${SRC_FILES}
+)
+
+add_subdirectory(extra)

--- a/tests/fixtures/controller_dependency/common/new_controller.c
+++ b/tests/fixtures/controller_dependency/common/new_controller.c
@@ -1,0 +1,4 @@
+#/**/inc\
+lude/**/"../idf_app/main/new_target_ui.h"
+
+void controller_boundary_negative_fixture(void) {}

--- a/tests/fixtures/controller_dependency/composed_property_source.cmake
+++ b/tests/fixtures/controller_dependency/composed_property_source.cmake
@@ -1,0 +1,14 @@
+set(SRC_FILES
+    "first.c"
+)
+
+idf_component_register(
+    SRCS ${SRC_FILES}
+)
+
+set(HIDDEN_STEM hidden)
+set(HIDDEN_EXT c)
+set_property(
+    TARGET ${COMPONENT_LIB} APPEND PROPERTY SOURCES
+    "${HIDDEN_STEM}.${HIDDEN_EXT}"
+)

--- a/tests/fixtures/controller_dependency/idf_app/main/new_target_ui.h
+++ b/tests/fixtures/controller_dependency/idf_app/main/new_target_ui.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void new_target_ui_render(void);

--- a/tests/fixtures/controller_dependency/include_sources.cmake
+++ b/tests/fixtures/controller_dependency/include_sources.cmake
@@ -1,0 +1,9 @@
+set(SRC_FILES
+    "first.c"
+)
+
+idf_component_register(
+    SRCS ${SRC_FILES}
+)
+
+include(extra_sources.cmake)

--- a/tests/fixtures/controller_dependency/inline_source.cmake
+++ b/tests/fixtures/controller_dependency/inline_source.cmake
@@ -1,0 +1,7 @@
+set(SRC_FILES
+    "first.c"
+)
+
+idf_component_register(
+    SRCS ${SRC_FILES} "hidden.c"
+)

--- a/tests/fixtures/controller_dependency/src_dirs.cmake
+++ b/tests/fixtures/controller_dependency/src_dirs.cmake
@@ -1,0 +1,8 @@
+set(SRC_FILES
+    "first.c"
+)
+
+idf_component_register(
+    SRC_DIRS hidden
+    SRCS ${SRC_FILES}
+)

--- a/tests/fixtures/controller_dependency/target_sources.cmake
+++ b/tests/fixtures/controller_dependency/target_sources.cmake
@@ -1,0 +1,9 @@
+set(SRC_FILES
+    "first.c"
+)
+
+idf_component_register(
+    SRCS ${SRC_FILES}
+)
+
+target_sources(${COMPONENT_LIB} PRIVATE "hidden.c")

--- a/tests/fixtures/controller_dependency/unsupported_sources.cmake
+++ b/tests/fixtures/controller_dependency/unsupported_sources.cmake
@@ -1,0 +1,9 @@
+set(SRC_FILES
+    "first.c"
+)
+
+list(APPEND SRC_FILES "hidden.c")
+
+idf_component_register(
+    SRCS ${SRC_FILES}
+)

--- a/tests/test_controller_input.c
+++ b/tests/test_controller_input.c
@@ -1,0 +1,96 @@
+#include "controller_input.h"
+#include "platform/platform_task.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#define EXPECTED_QUEUE_CAPACITY 63
+
+static controller_input_action_t s_actions[EXPECTED_QUEUE_CAPACITY + 2];
+static size_t s_action_count;
+static int s_rotation_ticks;
+static int s_reentrant_trace[2];
+static size_t s_reentrant_count;
+
+static void record_action(controller_input_action_t action) {
+    assert(s_action_count < (sizeof(s_actions) / sizeof(s_actions[0])));
+    s_actions[s_action_count++] = action;
+}
+static void record_rotation(int ticks) {
+    s_rotation_ticks = ticks;
+}
+
+static void reentrant_second(void *arg) {
+    (void)arg;
+    assert(s_reentrant_count < 2);
+    s_reentrant_trace[s_reentrant_count++] = 2;
+}
+
+static void reentrant_first(void *arg) {
+    (void)arg;
+    assert(s_reentrant_count < 2);
+    s_reentrant_trace[s_reentrant_count++] = 1;
+    assert(platform_task_post_to_ui(reentrant_second, NULL));
+}
+
+static void test_direct_dispatch_and_unset_handlers(void) {
+    controller_input_set_action_handler(NULL);
+    controller_input_set_rotation_handler(NULL);
+    controller_input_dispatch_action(CONTROLLER_INPUT_PLAY_PAUSE);
+    controller_input_dispatch_rotation(7);
+
+    controller_input_set_action_handler(record_action);
+    controller_input_set_rotation_handler(record_rotation);
+    controller_input_dispatch_action(CONTROLLER_INPUT_NEXT_TRACK);
+    controller_input_dispatch_rotation(-4);
+
+    assert(s_action_count == 1);
+    assert(s_actions[0] == CONTROLLER_INPUT_NEXT_TRACK);
+    assert(s_rotation_ticks == -4);
+}
+
+static void test_none_is_not_queued(void) {
+    assert(!controller_input_post_action(CONTROLLER_INPUT_NONE));
+}
+
+static void test_queue_fifo_capacity_and_full_failure(void) {
+    s_action_count = 0;
+    for (size_t i = 0; i < EXPECTED_QUEUE_CAPACITY; ++i) {
+        controller_input_action_t action =
+            (i % 2 == 0) ? CONTROLLER_INPUT_VOL_DOWN
+                         : CONTROLLER_INPUT_VOL_UP;
+        assert(controller_input_post_action(action));
+    }
+
+    assert(!controller_input_post_action(CONTROLLER_INPUT_PLAY_PAUSE));
+    platform_task_run_pending();
+
+    assert(s_action_count == EXPECTED_QUEUE_CAPACITY);
+    for (size_t i = 0; i < EXPECTED_QUEUE_CAPACITY; ++i) {
+        controller_input_action_t expected =
+            (i % 2 == 0) ? CONTROLLER_INPUT_VOL_DOWN
+                         : CONTROLLER_INPUT_VOL_UP;
+        assert(s_actions[i] == expected);
+    }
+}
+
+static void test_reentrant_post_runs_in_same_drain(void) {
+    s_reentrant_count = 0;
+    assert(platform_task_post_to_ui(reentrant_first, NULL));
+    platform_task_run_pending();
+
+    assert(s_reentrant_count == 2);
+    assert(s_reentrant_trace[0] == 1);
+    assert(s_reentrant_trace[1] == 2);
+}
+
+int main(void) {
+    test_direct_dispatch_and_unset_handlers();
+    test_none_is_not_queued();
+    test_queue_fifo_capacity_and_full_failure();
+    test_reentrant_post_runs_in_same_drain();
+    puts("controller input/task contracts passed");
+    return 0;
+}

--- a/tests/test_controller_presentation_dial.c
+++ b/tests/test_controller_presentation_dial.c
@@ -1,0 +1,183 @@
+#include "controller_presentation.h"
+#include "ui.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+static int s_update_calls;
+static const char *s_line1;
+static const char *s_line2;
+static bool s_playing;
+static float s_volume;
+static float s_volume_min;
+static float s_volume_max;
+static float s_volume_step;
+static int s_seek_position;
+static int s_length;
+static int s_status_calls;
+static int s_message_calls;
+static int s_zone_calls;
+static int s_network_calls;
+static int s_artwork_calls;
+static int s_volume_calls;
+static int s_battery_calls;
+static int s_picker_show_calls;
+static int s_picker_hide_calls;
+static int s_picker_scroll_delta;
+static int s_settings_calls;
+static bool s_picker_visible = true;
+static bool s_picker_current = true;
+
+void ui_init(void) {}
+void ui_loop_iter(void) {}
+void ui_update(const char *line1, const char *line2, bool playing,
+               float volume, float volume_min, float volume_max,
+               float volume_step, int seek_position, int length) {
+    ++s_update_calls;
+    s_line1 = line1;
+    s_line2 = line2;
+    s_playing = playing;
+    s_volume = volume;
+    s_volume_min = volume_min;
+    s_volume_max = volume_max;
+    s_volume_step = volume_step;
+    s_seek_position = seek_position;
+    s_length = length;
+}
+void ui_set_status(bool online) {
+    assert(online);
+    ++s_status_calls;
+}
+void ui_set_message(const char *msg) {
+    assert(strcmp(msg, "message") == 0);
+    ++s_message_calls;
+}
+void ui_set_zone_name(const char *zone_name) {
+    assert(strcmp(zone_name, "zone") == 0);
+    ++s_zone_calls;
+}
+void ui_show_zone_picker(const char **zone_names, const char **zone_ids,
+                         int zone_count, int selected_idx) {
+    assert(zone_count == 2);
+    assert(selected_idx == 1);
+    assert(strcmp(zone_names[0], "one") == 0);
+    assert(strcmp(zone_ids[1], "id-two") == 0);
+    ++s_picker_show_calls;
+}
+void ui_hide_zone_picker(void) {
+    ++s_picker_hide_calls;
+}
+bool ui_is_zone_picker_visible(void) {
+    return s_picker_visible;
+}
+int ui_zone_picker_get_selected(void) {
+    return 1;
+}
+void ui_zone_picker_get_selected_id(char *out, size_t len) {
+    snprintf(out, len, "%s", "id-two");
+}
+void ui_zone_picker_scroll(int delta) {
+    s_picker_scroll_delta = delta;
+}
+bool ui_zone_picker_is_current_selection(void) {
+    return s_picker_current;
+}
+void ui_set_artwork(const char *image_key) {
+    assert(strcmp(image_key, "art") == 0);
+    ++s_artwork_calls;
+}
+void ui_show_volume_change(float vol, float vol_step) {
+    assert(vol == 42.0f);
+    assert(vol_step == 1.0f);
+    ++s_volume_calls;
+}
+void ui_test_pattern(void) {}
+void ui_show_settings(void) {
+    ++s_settings_calls;
+}
+void ui_hide_settings(void) {}
+bool ui_is_settings_visible(void) {
+    return false;
+}
+void ui_set_update_available(const char *version) {
+    (void)version;
+}
+void ui_set_update_progress(int percent) {
+    (void)percent;
+}
+void ui_trigger_update(void) {}
+void ui_set_controls_visible(bool visible) {
+    (void)visible;
+}
+void ui_set_network_status(const char *status) {
+    assert(strcmp(status, "network") == 0);
+    ++s_network_calls;
+}
+void ui_update_battery(void) {
+    ++s_battery_calls;
+}
+int main(void) {
+    const char *names[] = {"one", "two"};
+    const char *ids[] = {"id-one", "id-two"};
+    char selected_id[16] = {0};
+
+    controller_presentation_update("track", "artist", "album", true, 42.0f,
+                                   2.0f, 98.0f, 0.5f, 13, 241);
+    controller_presentation_set_status(true);
+    controller_presentation_set_message("message");
+    controller_presentation_set_zone_name("zone");
+    controller_presentation_set_network_status("network");
+    controller_presentation_set_artwork("art");
+    controller_presentation_show_volume_change(42.0f, 1.0f);
+    controller_presentation_update_battery();
+    controller_presentation_show_zone_picker(names, ids, 2, 1);
+    controller_presentation_zone_picker_scroll(-1);
+    controller_presentation_zone_picker_get_selected_id(selected_id,
+                                                        sizeof(selected_id));
+    controller_presentation_hide_zone_picker();
+    controller_presentation_show_settings();
+
+    assert(s_update_calls == 1);
+    assert(strcmp(s_line1, "track") == 0);
+    assert(strcmp(s_line2, "artist") == 0);
+    assert(s_playing);
+    assert(s_volume == 42.0f);
+    assert(s_volume_min == 2.0f);
+    assert(s_volume_max == 98.0f);
+    assert(s_volume_step == 0.5f);
+    assert(s_seek_position == 13);
+    assert(s_length == 241);
+    assert(s_status_calls == 1);
+    assert(s_message_calls == 1);
+    assert(s_zone_calls == 1);
+    assert(s_network_calls == 1);
+    assert(s_artwork_calls == 1);
+    assert(s_volume_calls == 1);
+    assert(s_battery_calls == 1);
+    assert(s_picker_show_calls == 1);
+    assert(s_picker_hide_calls == 1);
+    assert(s_picker_scroll_delta == -1);
+    assert(controller_presentation_is_zone_picker_visible());
+    assert(controller_presentation_zone_picker_is_current_selection());
+    assert(strcmp(selected_id, "id-two") == 0);
+    assert(s_settings_calls == 1);
+
+    controller_presentation_update(NULL, NULL, NULL, false, -1.0f, -2.0f,
+                                   -3.0f, -4.0f, -5, -6);
+    assert(s_update_calls == 2);
+    assert(s_line1 == NULL);
+    assert(s_line2 == NULL);
+    assert(!s_playing);
+    assert(s_volume == -1.0f);
+    assert(s_volume_min == -2.0f);
+    assert(s_volume_max == -3.0f);
+    assert(s_volume_step == -4.0f);
+    assert(s_seek_position == -5);
+    assert(s_length == -6);
+
+    puts("Dial presentation adapter contracts passed");
+    return 0;
+}

--- a/tests/test_controller_presentation_frame.c
+++ b/tests/test_controller_presentation_frame.c
@@ -1,0 +1,175 @@
+#include "controller_presentation.h"
+#include "eink_ui.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+static int s_update_calls;
+static const char *s_line1;
+static const char *s_line2;
+static const char *s_line3;
+static bool s_playing;
+static float s_volume;
+static float s_volume_min;
+static float s_volume_max;
+static float s_volume_step;
+static int s_seek_position;
+static int s_length;
+static int s_status_calls;
+static int s_message_calls;
+static int s_zone_calls;
+static int s_network_calls;
+static int s_artwork_calls;
+static int s_volume_calls;
+static int s_battery_calls;
+static int s_picker_show_calls;
+static int s_picker_hide_calls;
+static int s_picker_scroll_delta;
+static int s_settings_calls;
+static bool s_picker_visible = true;
+static bool s_picker_current;
+
+void eink_ui_init(void) {}
+void eink_ui_set_status(bool online) {
+    assert(online);
+    ++s_status_calls;
+}
+void eink_ui_set_message(const char *msg) {
+    assert(strcmp(msg, "message") == 0);
+    ++s_message_calls;
+}
+void eink_ui_set_zone_name(const char *name) {
+    assert(strcmp(name, "zone") == 0);
+    ++s_zone_calls;
+}
+void eink_ui_set_network_status(const char *status) {
+    assert(strcmp(status, "network") == 0);
+    ++s_network_calls;
+}
+void eink_ui_post_zone_name(const char *name) {
+    (void)name;
+}
+void eink_ui_post_network_status(const char *status) {
+    (void)status;
+}
+void eink_ui_set_artwork(const char *image_key) {
+    assert(strcmp(image_key, "art") == 0);
+    ++s_artwork_calls;
+}
+void eink_ui_show_volume_change(float vol, float vol_step) {
+    assert(vol == 42.0f);
+    assert(vol_step == 1.0f);
+    ++s_volume_calls;
+}
+void eink_ui_update(const char *line1, const char *line2, const char *line3,
+                    bool playing, float volume, float volume_min,
+                    float volume_max, float volume_step, int seek_position,
+                    int length) {
+    ++s_update_calls;
+    s_line1 = line1;
+    s_line2 = line2;
+    s_line3 = line3;
+    s_playing = playing;
+    s_volume = volume;
+    s_volume_min = volume_min;
+    s_volume_max = volume_max;
+    s_volume_step = volume_step;
+    s_seek_position = seek_position;
+    s_length = length;
+}
+void eink_ui_show_zone_picker(void) {
+    ++s_picker_show_calls;
+}
+void eink_ui_hide_zone_picker(void) {
+    ++s_picker_hide_calls;
+}
+bool eink_ui_is_zone_picker_visible(void) {
+    return s_picker_visible;
+}
+void eink_ui_zone_picker_scroll(int delta) {
+    s_picker_scroll_delta = delta;
+}
+void eink_ui_zone_picker_get_selected_id(char *out, size_t len) {
+    snprintf(out, len, "%s", "frame-id");
+}
+bool eink_ui_zone_picker_is_current_selection(void) {
+    return s_picker_current;
+}
+void eink_ui_set_ble_status(bool connected) {
+    (void)connected;
+}
+void eink_ui_update_battery(void) {
+    ++s_battery_calls;
+}
+void eink_ui_show_settings(void) {
+    ++s_settings_calls;
+}
+void eink_ui_process(void) {}
+
+int main(void) {
+    const char *names[] = {"one", "two"};
+    const char *ids[] = {"id-one", "id-two"};
+    char selected_id[16] = {0};
+
+    controller_presentation_update("track", "artist", "album", true, 42.0f,
+                                   2.0f, 98.0f, 0.5f, 13, 241);
+    controller_presentation_set_status(true);
+    controller_presentation_set_message("message");
+    controller_presentation_set_zone_name("zone");
+    controller_presentation_set_network_status("network");
+    controller_presentation_set_artwork("art");
+    controller_presentation_show_volume_change(42.0f, 1.0f);
+    controller_presentation_update_battery();
+    controller_presentation_show_zone_picker(names, ids, 2, 1);
+    controller_presentation_zone_picker_scroll(1);
+    controller_presentation_zone_picker_get_selected_id(selected_id,
+                                                        sizeof(selected_id));
+    controller_presentation_hide_zone_picker();
+    controller_presentation_show_settings();
+
+    assert(s_update_calls == 1);
+    assert(strcmp(s_line1, "track") == 0);
+    assert(strcmp(s_line2, "artist") == 0);
+    assert(strcmp(s_line3, "album") == 0);
+    assert(s_playing);
+    assert(s_volume == 42.0f);
+    assert(s_volume_min == 2.0f);
+    assert(s_volume_max == 98.0f);
+    assert(s_volume_step == 0.5f);
+    assert(s_seek_position == 13);
+    assert(s_length == 241);
+    assert(s_status_calls == 1);
+    assert(s_message_calls == 1);
+    assert(s_zone_calls == 1);
+    assert(s_network_calls == 1);
+    assert(s_artwork_calls == 1);
+    assert(s_volume_calls == 1);
+    assert(s_battery_calls == 1);
+    assert(s_picker_show_calls == 1);
+    assert(s_picker_hide_calls == 1);
+    assert(s_picker_scroll_delta == 1);
+    assert(controller_presentation_is_zone_picker_visible());
+    assert(!controller_presentation_zone_picker_is_current_selection());
+    assert(strcmp(selected_id, "frame-id") == 0);
+    assert(s_settings_calls == 1);
+
+    controller_presentation_update(NULL, NULL, NULL, false, -1.0f, -2.0f,
+                                   -3.0f, -4.0f, -5, -6);
+    assert(s_update_calls == 2);
+    assert(s_line1 == NULL);
+    assert(s_line2 == NULL);
+    assert(s_line3 == NULL);
+    assert(!s_playing);
+    assert(s_volume == -1.0f);
+    assert(s_volume_min == -2.0f);
+    assert(s_volume_max == -3.0f);
+    assert(s_volume_step == -4.0f);
+    assert(s_seek_position == -5);
+    assert(s_length == -6);
+
+    puts("Frame presentation adapter contracts passed");
+    return 0;
+}


### PR DESCRIPTION
Refs #190

## Stack

Depends on #218, which depends on #217 and #216. This first #190 slice intentionally remains stacked and draft.

## What this does

- records the target controller dependency DAG separately from the current graph
- freezes all 215 repository-local direct quoted-include edges for Dial and Frame
- machine-classifies 25 existing forbidden edges with owner, reason, and retirement issue
- fails on new/stale edges, ownerless forbidden edges, unresolved local includes, unsupported preprocessor include forms, and unsupported CMake source inventory changes
- characterizes input queue semantics and both Dial/Frame presentation adapters
- wires the policy, adversarial fixtures, and native contracts into test-shared

This does not move directories, change firmware behavior, migrate or share NVS between devices, or claim component/link/runtime isolation.

## Validation

- dependency policy: 190 allowed, 25 grandfathered
- seven adversarial CMake source bypass fixtures pass
- comment-separated and line-spliced new-header fixture is rejected
- controller input, Dial presentation, and Frame presentation native tests pass with -Wall -Wextra -Werror
- clean ESP-IDF v5.5.5 ESP32-S3 Dial and Frame builds pass
- both targets select PERF optimization and not DEBUG
- final independent execute review: PASS
- final independent execute dissent: PASS

## Merge gates

- keep #190 open; this is only the first strangler slice
- rebase the final stack onto master and require the full workflow green
- preserve the exact #216 Frame artifact until hardware qualification is complete
- do not merge any stack PR without explicit approval