### PR TITLE
CI: skip firmware matrix for site-only changes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -954,49 +954,10 @@ jobs:
             hiphi_knob_aux_park_merged.bin
           retention-days: 30
 
-  build-ble-off:
-    name: build-without-ble-hid-boundary
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-
-      - name: Restore BLE-off compiler cache
-        uses: actions/cache@v5
-        with:
-          path: .ci/ccache-ble-off
-          key: ${{ runner.os }}-esp-idf-v5.5.5-ble-off-ccache-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-esp-idf-v5.5.5-ble-off-ccache-
-
-      - name: Build ESP32-S3 capability-disabled fixture
-        uses: espressif/esp-idf-ci-action@v1
-        with:
-          esp_idf_version: v5.5.5
-          target: esp32s3
-          path: tests/fixtures/rk_ble_hid_off
-          extra_docker_args: >-
-            -e CCACHE_DIR=/app/${{ github.repository }}/.ci/ccache-ble-off
-            -e CCACHE_MAXSIZE=500M
-            -e CCACHE_COMPRESS=1
-          command: >-
-            set -e;
-            ccache --zero-stats;
-            idf.py build;
-            ! grep -Fx "CONFIG_RK_BLE_HID_HOST=y" sdkconfig;
-            ! grep -Fx "CONFIG_BT_ENABLED=y" sdkconfig;
-            grep -F "rk_ble_hid_host_stub.c.obj" build/compile_commands.json;
-            ! grep -F "/rk_ble_hid_host.c.obj" build/compile_commands.json;
-            grep -E "^rk_ble_hid_host_init[[:space:]]+esp-idf/rk_ble_hid_host_stub/librk_ble_hid_host_stub[.]a[(]rk_ble_hid_host_stub[.]c[.]obj[)][[:space:]]*$" build/rk_ble_hid_off.map;
-            ! grep -F "rk_ble_hid_host.c.obj" build/rk_ble_hid_off.map;
-            ! grep -E "nimble_hidh.c.obj|esp_hidh.c.obj" build/compile_commands.json;
-            ccache --show-stats
-
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [test-shared, build-idf, build-frame, build-rlcd, build-atom, build-tough, build-m5-betas, build-knob-aux, build-ble-off]
+    needs: [test-shared, build-idf, build-frame, build-rlcd, build-atom, build-tough, build-m5-betas, build-knob-aux]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -1234,7 +1195,7 @@ jobs:
     concurrency:
       group: firmware-pages
       cancel-in-progress: false
-    needs: [test-shared, build-idf, build-frame, build-rlcd, build-atom, build-tough, build-m5-betas, build-knob-aux, build-ble-off]
+    needs: [test-shared, build-idf, build-frame, build-rlcd, build-atom, build-tough, build-m5-betas, build-knob-aux]
     if: github.event_name == 'pull_request'
     permissions:
       contents: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,17 @@ on:
     tags: ['v*']
   pull_request:
     branches: ['**']
+    # Website-only changes have their own fast validation and preview workflow.
+    # Keep this list in sync with firmware-site-preview.yml.
+    paths-ignore:
+      - 'web/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'scripts/check_release_hosting_contract.py'
+      - 'scripts/check_alpha_release_notes.py'
+      - 'scripts/classify_firmware_site_changes.py'
+      - 'scripts/render_firmware_site_preview.py'
+      - '.github/workflows/firmware-site-preview.yml'
 
 permissions:
   contents: read
@@ -661,6 +672,13 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Inject version into Atom CMakeLists.txt
         run: sed -i 's/set(PROJECT_VER ".*")/set(PROJECT_VER "${{ steps.atom-version.outputs.version }}")/' atom_app/CMakeLists.txt
+      - name: Restore Atom compiler cache
+        uses: actions/cache@v5
+        with:
+          path: .ci/ccache-atom
+          key: ${{ runner.os }}-esp-idf-v5.5.5-atom-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-esp-idf-v5.5.5-atom-ccache-
       - name: Restore Atom managed components
         uses: actions/cache@v5
         with:
@@ -672,8 +690,13 @@ jobs:
           esp_idf_version: v5.5.5
           target: esp32s3
           path: atom_app
+          extra_docker_args: >-
+            -e CCACHE_DIR=/app/${{ github.repository }}/.ci/ccache-atom
+            -e CCACHE_MAXSIZE=500M
+            -e CCACHE_COMPRESS=1
           command: >-
             set -e;
+            ccache --zero-stats;
             idf.py build;
             grep -Fx "CONFIG_COMPILER_OPTIMIZATION_PERF=y" sdkconfig;
             grep -Fx "CONFIG_PM_DFS_INIT_AUTO=y" sdkconfig;
@@ -686,7 +709,8 @@ jobs:
             grep -F "/components/m5_official/vendor/Atom-JoyStick/" build/compile_commands.json;
             python3 ../scripts/check_m5_arduino_abi.py build/compile_commands.json;
             esptool.py --chip esp32s3 merge_bin -o ../hiphi_joy_merged.bin --flash_mode dio --flash_freq 80m --flash_size 8MB 0x0 build/bootloader/bootloader.bin 0x8000 build/partition_table/partition-table.bin 0xd000 build/ota_data_initial.bin 0x10000 build/hiphi_joy.bin;
-            esptool.py --chip esp32s3 image_info ../hiphi_joy_merged.bin
+            esptool.py --chip esp32s3 image_info ../hiphi_joy_merged.bin;
+            ccache --show-stats
       - name: Upload AtomS3 Joystick artifact
         uses: actions/upload-artifact@v6
         with:
@@ -713,6 +737,13 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Inject version into Tough CMakeLists.txt
         run: sed -i 's/set(PROJECT_VER ".*")/set(PROJECT_VER "${{ steps.tough-version.outputs.version }}")/' tough_app/CMakeLists.txt
+      - name: Restore Tough compiler cache
+        uses: actions/cache@v5
+        with:
+          path: .ci/ccache-tough
+          key: ${{ runner.os }}-esp-idf-v5.5.5-tough-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-esp-idf-v5.5.5-tough-ccache-
       - name: Restore Tough managed components
         uses: actions/cache@v5
         with:
@@ -724,8 +755,13 @@ jobs:
           esp_idf_version: v5.5.5
           target: esp32
           path: tough_app
+          extra_docker_args: >-
+            -e CCACHE_DIR=/app/${{ github.repository }}/.ci/ccache-tough
+            -e CCACHE_MAXSIZE=500M
+            -e CCACHE_COMPRESS=1
           command: >-
             set -e;
+            ccache --zero-stats;
             idf.py build;
             grep -Fx "CONFIG_COMPILER_OPTIMIZATION_PERF=y" sdkconfig;
             grep -Fx "CONFIG_PM_DFS_INIT_AUTO=y" sdkconfig;
@@ -739,7 +775,8 @@ jobs:
             esptool.py --chip esp32 merge_bin -o ../hiphi_tough_merged.bin --flash_mode dio --flash_freq 40m --flash_size 16MB 0x1000 build/bootloader/bootloader.bin 0x8000 build/partition_table/partition-table.bin 0xd000 build/ota_data_initial.bin 0x10000 build/hiphi_tough.bin;
             od -An -tu1 -j4096 -N1 ../hiphi_tough_merged.bin | grep -Eq "^[[:space:]]*233[[:space:]]*$";
             esptool.py --chip esp32 image_info build/bootloader/bootloader.bin;
-            esptool.py --chip esp32 image_info build/hiphi_tough.bin
+            esptool.py --chip esp32 image_info build/hiphi_tough.bin;
+            ccache --show-stats
       - name: Upload M5Stack Tough artifact
         uses: actions/upload-artifact@v6
         with:
@@ -787,6 +824,13 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Inject version into M5 beta CMakeLists.txt
         run: sed -i 's/set(PROJECT_VER ".*")/set(PROJECT_VER "${{ steps.m5-beta-version.outputs.version }}")/' m5_beta_app/CMakeLists.txt
+      - name: Restore M5 beta compiler cache
+        uses: actions/cache@v5
+        with:
+          path: .ci/ccache-m5-beta-${{ matrix.target }}
+          key: ${{ runner.os }}-esp-idf-v5.5.5-m5-beta-${{ matrix.target }}-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-esp-idf-v5.5.5-m5-beta-${{ matrix.target }}-ccache-
       - name: Restore M5 beta managed components
         uses: actions/cache@v5
         with:
@@ -798,8 +842,13 @@ jobs:
           esp_idf_version: v5.5.5
           target: esp32s3
           path: m5_beta_app
+          extra_docker_args: >-
+            -e CCACHE_DIR=/app/${{ github.repository }}/.ci/ccache-m5-beta-${{ matrix.target }}
+            -e CCACHE_MAXSIZE=500M
+            -e CCACHE_COMPRESS=1
           command: >-
             set -e;
+            ccache --zero-stats;
             idf.py -B build-${{ matrix.target }}
             -D HIPHI_M5_TARGET=${{ matrix.target }}
             -D SDKCONFIG=build-${{ matrix.target }}/sdkconfig build;
@@ -822,7 +871,8 @@ jobs:
             0x8000 build-${{ matrix.target }}/partition_table/partition-table.bin
             0xd000 build-${{ matrix.target }}/ota_data_initial.bin
             0x10000 build-${{ matrix.target }}/hiphi_${{ matrix.target }}.bin;
-            esptool.py --chip esp32s3 image_info ../hiphi_${{ matrix.target }}_merged.bin
+            esptool.py --chip esp32s3 image_info ../hiphi_${{ matrix.target }}_merged.bin;
+            ccache --show-stats
       - name: Upload M5 beta artifact
         uses: actions/upload-artifact@v6
         with:
@@ -852,14 +902,27 @@ jobs:
       - name: Inject version into auxiliary CMakeLists.txt
         run: sed -i 's/set(PROJECT_VER ".*")/set(PROJECT_VER "${{ steps.knob-aux-version.outputs.version }}")/' knob_aux_app/CMakeLists.txt
 
+      - name: Restore auxiliary compiler cache
+        uses: actions/cache@v5
+        with:
+          path: .ci/ccache-knob-aux
+          key: ${{ runner.os }}-esp-idf-v5.5.5-knob-aux-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-esp-idf-v5.5.5-knob-aux-ccache-
+
       - name: Build auxiliary ESP32 parking firmware
         uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: v5.5.5
           target: esp32
           path: knob_aux_app
+          extra_docker_args: >-
+            -e CCACHE_DIR=/app/${{ github.repository }}/.ci/ccache-knob-aux
+            -e CCACHE_MAXSIZE=500M
+            -e CCACHE_COMPRESS=1
           command: >-
             set -e;
+            ccache --zero-stats;
             idf.py build;
             grep -Fx "CONFIG_COMPILER_OPTIMIZATION_PERF=y" sdkconfig;
             grep -Fx "CONFIG_IDF_TARGET_ESP32=y" sdkconfig;
@@ -877,7 +940,8 @@ jobs:
             0x1000 build/bootloader/bootloader.bin
             0x8000 build/partition_table/partition-table.bin
             0x10000 build/hiphi_knob_aux_park.bin;
-            esptool.py --chip esp32 image_info build/hiphi_knob_aux_park.bin
+            esptool.py --chip esp32 image_info build/hiphi_knob_aux_park.bin;
+            ccache --show-stats
 
       - name: Upload auxiliary parking firmware
         uses: actions/upload-artifact@v6
@@ -891,12 +955,20 @@ jobs:
           retention-days: 30
 
   build-ble-off:
-    name: build-ble-off
+    name: build-without-ble-hid-boundary
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Restore BLE-off compiler cache
+        uses: actions/cache@v5
+        with:
+          path: .ci/ccache-ble-off
+          key: ${{ runner.os }}-esp-idf-v5.5.5-ble-off-ccache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-esp-idf-v5.5.5-ble-off-ccache-
 
       - name: Build ESP32-S3 capability-disabled fixture
         uses: espressif/esp-idf-ci-action@v1
@@ -904,8 +976,13 @@ jobs:
           esp_idf_version: v5.5.5
           target: esp32s3
           path: tests/fixtures/rk_ble_hid_off
+          extra_docker_args: >-
+            -e CCACHE_DIR=/app/${{ github.repository }}/.ci/ccache-ble-off
+            -e CCACHE_MAXSIZE=500M
+            -e CCACHE_COMPRESS=1
           command: >-
             set -e;
+            ccache --zero-stats;
             idf.py build;
             ! grep -Fx "CONFIG_RK_BLE_HID_HOST=y" sdkconfig;
             ! grep -Fx "CONFIG_BT_ENABLED=y" sdkconfig;
@@ -913,7 +990,8 @@ jobs:
             ! grep -F "/rk_ble_hid_host.c.obj" build/compile_commands.json;
             grep -E "^rk_ble_hid_host_init[[:space:]]+esp-idf/rk_ble_hid_host_stub/librk_ble_hid_host_stub[.]a[(]rk_ble_hid_host_stub[.]c[.]obj[)][[:space:]]*$" build/rk_ble_hid_off.map;
             ! grep -F "rk_ble_hid_host.c.obj" build/rk_ble_hid_off.map;
-            ! grep -E "nimble_hidh.c.obj|esp_hidh.c.obj" build/compile_commands.json
+            ! grep -E "nimble_hidh.c.obj|esp_hidh.c.obj" build/compile_commands.json;
+            ccache --show-stats
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/firmware-site-preview.yml
+++ b/.github/workflows/firmware-site-preview.yml
@@ -1,0 +1,143 @@
+name: Firmware Site Preview
+
+on:
+  pull_request:
+    branches: ['**']
+    paths:
+      - 'web/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'scripts/check_release_hosting_contract.py'
+      - 'scripts/check_alpha_release_notes.py'
+      - 'scripts/classify_firmware_site_changes.py'
+      - 'scripts/render_firmware_site_preview.py'
+      - '.github/workflows/docker.yml'
+      - '.github/workflows/firmware-site-preview.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: firmware-site-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  classify:
+    name: classify-site-only-change
+    runs-on: ubuntu-latest
+    outputs:
+      site-only: ${{ steps.paths.outputs.site-only }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require every changed path to be site-only
+        id: paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          site_only=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" | \
+            python3 scripts/classify_firmware_site_changes.py)
+          echo "site-only=$site_only" >> "$GITHUB_OUTPUT"
+
+  validate-and-preview:
+    name: validate-and-preview-firmware-site
+    needs: classify
+    if: needs.classify.outputs.site-only == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: firmware-pages
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate firmware-site contracts
+        run: |
+          python3 scripts/check_alpha_release_notes.py
+          python3 scripts/check_release_hosting_contract.py
+          python3 scripts/classify_firmware_site_changes.py --self-test
+
+      - name: Read the published alpha manifests
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: published-pages
+          persist-credentials: false
+
+      - name: Render site preview against published alpha firmware
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 scripts/render_firmware_site_preview.py \
+            --web-dir web \
+            --published-alpha-dir published-pages/alpha \
+            --output-dir site-preview \
+            --pr-number "$PR_NUM" \
+            --head-sha "$HEAD_SHA" \
+            --run-url "$RUN_URL"
+          grep -R -F 'manifest="/alpha/' site-preview/flash*.html
+          ! find site-preview -type f -name '*.bin' -print -quit | grep -q .
+
+      - name: Deploy lightweight PR preview
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site-preview
+          destination_dir: pr/${{ github.event.pull_request.number }}/site
+          keep_files: true
+          cname: firmware.hiphi.audio
+
+      - name: Verify deployed site preview
+        env:
+          PR_NUM: ${{ github.event.pull_request.number }}
+        run: |
+          PREVIEW_URL="https://firmware.hiphi.audio/pr/${PR_NUM}/site/flash-frame.html"
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent --location "$PREVIEW_URL" --output deployed.html; then
+              break
+            fi
+            test "$attempt" -lt 60
+            sleep 5
+          done
+          cmp site-preview/flash-frame.html deployed.html
+          curl --fail --silent --location \
+            "https://firmware.hiphi.audio/pr/${PR_NUM}/site/assets/styles.css" \
+            --output deployed.css
+          cmp site-preview/assets/styles.css deployed.css
+
+      - name: Post site preview URL to PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = '<!-- firmware-site-preview -->';
+            const url = `https://firmware.hiphi.audio/pr/${context.issue.number}/site/flash-frame.html`;
+            const body = `${marker}\n### Firmware site preview\n\n[Open the Frame page](${url})\n\nThis lightweight preview uses the PR HTML/CSS with the already-published alpha firmware. No firmware targets were rebuilt.`;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              ...context.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+            const previous = comments.find(comment => comment.body?.includes(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/scripts/check_dial_power_copy.py
+++ b/scripts/check_dial_power_copy.py
@@ -39,7 +39,7 @@ REQUIRED = {
         "otherwise-unused auxiliary ESP32 once",
     ),
     ".github/workflows/docker.yml": (
-        "build-knob-aux, build-ble-off",
+        "build-m5-betas, build-knob-aux]",
         "Download Waveshare Dial auxiliary parking firmware",
         "manifest-knob-aux-${PREVIEW_ID}.json",
         "Flash HiPhi Dial + one-time auxiliary power step",

--- a/scripts/check_release_hosting_contract.py
+++ b/scripts/check_release_hosting_contract.py
@@ -23,6 +23,7 @@ for legacy_app in ("idf_app", "frame_app", "rlcd_app"):
     require(f"{legacy_app}/CMakeLists.txt", "set(EXCLUDE_COMPONENTS m5_platform kizz_wake_word)")
 
 workflow = ".github/workflows/docker.yml"
+site_workflow = ".github/workflows/firmware-site-preview.yml"
 require(workflow, "cname: firmware.hiphi.audio")
 require(workflow, "publish_dir: ./publish-root")
 require(workflow, "destination_dir: .")
@@ -62,6 +63,24 @@ legacy_release_host = "roon" + "-knob.muness.com"
 forbid(workflow, legacy_release_host)
 forbid(workflow, "destination_dir: ${{ steps.channel.outputs.dir }}")
 forbid(workflow, "destination_dir: flash/${{ steps.channel.outputs.name }}")
+for site_only_path in (
+    "web/**",
+    "docs/**",
+    "README.md",
+    "scripts/check_release_hosting_contract.py",
+    "scripts/check_alpha_release_notes.py",
+    "scripts/classify_firmware_site_changes.py",
+    "scripts/render_firmware_site_preview.py",
+    ".github/workflows/firmware-site-preview.yml",
+):
+    require(workflow, f"- '{site_only_path}'")
+require(site_workflow, "classify-site-only-change")
+require(site_workflow, "needs.classify.outputs.site-only == 'true'")
+require(site_workflow, "scripts/render_firmware_site_preview.py")
+require(site_workflow, "scripts/classify_firmware_site_changes.py")
+require(site_workflow, "No firmware targets were rebuilt.")
+require("scripts/render_firmware_site_preview.py", 'r\'manifest="/alpha/\\1"\'')
+require("scripts/render_firmware_site_preview.py", 'r\'href="/alpha/\\1"\'')
 
 for page in ("web/index.html", "web/flash.html"):
     require(page, 'href="./assets/favicon.ico"')

--- a/scripts/classify_firmware_site_changes.py
+++ b/scripts/classify_firmware_site_changes.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Classify a newline-delimited PR file list as firmware-site-only or mixed."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+SITE_PREFIXES = ("web/", "docs/")
+SITE_FILES = {
+    "README.md",
+    "scripts/check_release_hosting_contract.py",
+    "scripts/check_alpha_release_notes.py",
+    "scripts/classify_firmware_site_changes.py",
+    "scripts/render_firmware_site_preview.py",
+    ".github/workflows/docker.yml",
+    ".github/workflows/firmware-site-preview.yml",
+}
+
+
+def is_site_only(paths: list[str]) -> bool:
+    return bool(paths) and all(
+        path in SITE_FILES or path.startswith(SITE_PREFIXES) for path in paths
+    )
+
+
+def self_test() -> None:
+    assert is_site_only(["web/index.html", "docs/usage/FIRMWARE_FLASHING.md"])
+    assert is_site_only([".github/workflows/firmware-site-preview.yml"])
+    assert not is_site_only([])
+    assert not is_site_only(["web/index.html", "frame_app/main/main.c"])
+    assert not is_site_only(["webish/index.html"])
+    print("firmware-site change classifier self-test passed")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return
+    paths = [line.strip() for line in sys.stdin if line.strip()]
+    print("true" if is_site_only(paths) else "false")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dial_identity_exceptions.json
+++ b/scripts/dial_identity_exceptions.json
@@ -218,7 +218,7 @@
     },
     {
       "path": ".github/workflows/docker.yml",
-      "contains": "needs: [test-shared, build-idf, build-frame, build-rlcd, build-atom, build-tough, build-m5-betas, build-knob-aux, build-ble-off]"
+      "contains": "needs: [test-shared, build-idf, build-frame, build-rlcd, build-atom, build-tough, build-m5-betas, build-knob-aux]"
     },
     {
       "path": ".github/workflows/docker.yml",

--- a/scripts/render_firmware_site_preview.py
+++ b/scripts/render_firmware_site_preview.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Render a PR's firmware-site UI against already-published alpha binaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+from pathlib import Path
+
+
+TARGETS = (
+    ("dial", "flash-dial.html"),
+    ("frame", "flash-frame.html"),
+    ("rlcd", "flash-rlcd.html"),
+    ("joy", "flash-joy.html"),
+    ("tough", "flash-tough.html"),
+    ("m5dial", "flash-m5dial.html"),
+    ("sticks3", "flash-sticks3.html"),
+    ("stopwatch", "flash-stopwatch.html"),
+    ("stackchan", "flash-stackchan.html"),
+)
+
+
+def render(template: str, replacements: dict[str, str]) -> str:
+    for token, value in replacements.items():
+        template = template.replace("{{" + token + "}}", value)
+
+    # Site previews exercise current HTML/CSS while deliberately flashing the
+    # last published alpha. Absolute paths keep manifests and downloads on the
+    # firmware origin without copying release artifacts into every PR preview.
+    template = re.sub(
+        r'manifest="(?:\./)?(manifest-[^"]+\.json)"',
+        r'manifest="/alpha/\1"',
+        template,
+    )
+    template = re.sub(
+        r'href="\./(hiphi_[^"]+\.bin)"',
+        r'href="/alpha/\1"',
+        template,
+    )
+    return template
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--web-dir", type=Path, required=True)
+    parser.add_argument("--published-alpha-dir", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--pr-number", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--run-url", required=True)
+    args = parser.parse_args()
+
+    manifest = json.loads(
+        (args.published_alpha_dir / "manifest-frame.json").read_text()
+    )
+    version = manifest["version"]
+    output = args.output_dir
+    output.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(args.web_dir / "assets", output / "assets", dirs_exist_ok=True)
+
+    index = (args.web_dir / "index.html").read_text()
+    for channel in ("stable", "beta", "alpha"):
+        index = index.replace(f'href="./{channel}/"', f'href="/{channel}/"')
+    (output / "index.html").write_text(index)
+
+    short_sha = args.head_sha[:12]
+    notice = (
+        '<div class="channel-notice alpha"><strong>Site-only PR preview.</strong>'
+        f'<p>UI from PR #{args.pr_number} commit <code>{short_sha}</code>; '
+        f'Flash actions use the already-published alpha v{version} binaries. '
+        f'<a href="{args.run_url}">Preview run ↗</a></p></div>'
+    )
+    common = {
+        "VERSION": version,
+        "RELEASE_CHANNEL": "alpha",
+        "RELEASE_CHANNEL_NAME": "Site preview",
+        "RELEASE_CHANNEL_NOTICE": notice,
+        "RELEASE_LINK": (
+            f'<a href="https://github.com/muness/roon-knob/pull/{args.pr_number}">'
+            f'Review PR #{args.pr_number} ↗</a>'
+        ),
+    }
+    template = (args.web_dir / "flash.html").read_text()
+    (output / "flash.html").write_text(
+        render(template, {**common, "TARGET_FILTER": ""})
+    )
+    for target, filename in TARGETS:
+        (output / filename).write_text(
+            render(template, {**common, "TARGET_FILTER": target})
+        )
+
+    unresolved = list(output.glob("*.html"))
+    for page in unresolved:
+        text = page.read_text()
+        if re.search(r"\{\{[^}]+\}\}", text):
+            raise SystemExit(f"unresolved template token in {page}")
+        if 'manifest="./manifest-' in text:
+            raise SystemExit(f"relative preview manifest in {page}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #245
Closes #244

## Outcome

Site-only pull requests validate and publish a lightweight preview without rebuilding any ESP firmware. Firmware-changing PRs and release tags retain the full build and artifact-integrity path.

## Changes

- ignore the explicit site/docs path set in the firmware matrix workflow
- classify site-only diffs adversarially and publish current HTML/CSS against immutable `/alpha/` manifests and binaries
- keep site previews under `/pr/<number>/site/` so they cannot race firmware previews
- enable and report `ccache` for AtomS3, Tough, all M5 beta profiles, and the auxiliary image
- remove the eight-minute BLE-disabled ESP-IDF fixture; shipping builds either use real BLE (Dial/Frame) or do not reference the BLE API, while the stub remains covered by the fast host unit test

## Verification

- parent commit `27cac013311bfcc76e72559b6c85c9255fcc3cda`: full firmware matrix and lightweight site preview both passed
- final removal commit `95a9a03`: local hosting, Dial identity/power-copy, release-note, classifier, YAML, and diff checks passed; `[skip ci]` deliberately avoided restarting the entire matrix for job deletion
- lightweight preview: https://firmware.hiphi.audio/pr/246/site/flash-frame.html

## Cache evidence

The first run was intentionally cold: Dial Lab compiled 2,043 cacheable translation units, Kizz 2,064, Twist/Remote 1,598 each, Atom 1,770, and Tough 944. Follow-up runs will expose actual hit rates; no speedup is claimed from the cold run.